### PR TITLE
Update to new observers API.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -241,10 +241,10 @@ element.
       }
     },
 
-    observers: {
-      'url method headers contentType body sync handleAs withCredentials auto':
-        'requestOptionsChanged'
-    },
+    observers: [
+      'requestOptionsChanged(url, method, headers,' +
+        'contentType, body, sync, handleAs, withCredentials, auto)'
+    ],
 
     configure: function() {
       return {


### PR DESCRIPTION
This change is dependent on https://github.com/Polymer/polymer/pull/1422 being merged, and updates to match the new `observers` API, which now takes an array of string-based method signatures.