### PR TITLE
fix missing custom headers

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -291,7 +291,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     get requestHeaders() {
-      var headers = Object.create(this.headers || {});
+      var headers = {},
+          header;
+
+      if(this.headers instanceof Object) {
+        for(header in this.headers) {
+          headers[header] = this.headers[header].toString();
+        }
+      }
 
       if (!('content-type' in headers)) {
         headers['content-type'] = this.contentType;

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -291,17 +291,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     get requestHeaders() {
-      var headers = {},
+      var headers = {
+            'content-type': this.contentType
+          },
           header;
 
       if(this.headers instanceof Object) {
         for(header in this.headers) {
           headers[header] = this.headers[header].toString();
         }
-      }
-
-      if (!('content-type' in headers)) {
-        headers['content-type'] = this.contentType;
       }
 
       return headers;

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -99,6 +99,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(options.headers['custom-header']).to.be.an('string');
           expect(options.headers.hasOwnProperty('custom-header')).to.be.equal(true);
         });
+
+        test('non-objects in headers are not applied', function () {
+          ajax.headers = 'invalid';
+          var options = ajax.toRequestOptions();
+
+          expect(Object.keys(options.headers).length).to.be.equal(1);
+        });
       });
 
       suite('when properties are changed', function () {

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -89,6 +89,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ajax.toRequestOptions().async).to.be.eql(true);
         });
       });
+      
+      suite('when setting custom headers', function () {
+        test('are present in the request headers', function () {
+          ajax.headers['custom-header'] = 'valid';
+          var options = ajax.toRequestOptions();
+
+          expect(options.headers).to.be.ok;
+          expect(options.headers['custom-header']).to.be.an('string');
+          expect(options.headers.hasOwnProperty('custom-header')).to.be.equal(true);
+        });
+      });
 
       suite('when properties are changed', function () {
         test('generates simple-request elements that reflect the change', function () {


### PR DESCRIPTION
When setting a custom header line via `params` attribute, it is not sent in the request headers.

After [invoking `Object.create`](https://github.com/PolymerElements/iron-ajax/blob/master/iron-ajax.html#L294) on `options.headers`,  [`Object.keys(options.headers)` is called on it](https://github.com/PolymerElements/iron-ajax/blob/master/iron-request.html#L172), but the array it returns does not contain the custom created headers.

![screen shot 2015-05-01 at 06 20 27](https://cloud.githubusercontent.com/assets/473924/7427267/dbce0da4-efd7-11e4-880d-ce47950f0b3e.png)