### PR TITLE
Handle status codes better, improve request access

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -18,7 +18,7 @@ The `iron-ajax` element exposes network request functionality.
         url="http://gdata.youtube.com/feeds/api/videos/"
         params='{"alt":"json", "q":"chrome"}'
         handle-as="json"
-        on-response="{{handleResponse}}"></iron-ajax>
+        on-response="handleResponse"></iron-ajax>
 
 With `auto` set to `true`, the element performs a request whenever
 its `url`, `params` or `body` properties are changed. Automatically generated
@@ -357,16 +357,16 @@ element.
       this._setLastRequest(request);
 
       this.fire('request', {
-        xhr: request.xhr,
+        request: request,
         options: requestOptions
       });
 
       return request;
     },
 
-    handleResponse: function(response) {
-      this._setLastResponse(response);
-      this.fire('response', response);
+    handleResponse: function(request) {
+      this._setLastResponse(request.response);
+      this.fire('response', request);
     },
 
     handleError: function(error) {

--- a/iron-request.html
+++ b/iron-request.html
@@ -119,6 +119,23 @@ iron-request can be used to perform XMLHttpRequests.
     },
 
     /**
+     * Succeeded is true if the request succeeded. The request succeeded if the
+     * status code is greater-than-or-equal-to 200, and less-than 300. Also,
+     * the status code 0 is accepted as a success even though the outcome may
+     * be ambiguous.
+     *
+     * @return boolean
+     */
+    get succeeded() {
+      var status = this.xhr.status || 0;
+
+      // Note: if we are using the file:// protocol, the status code will be 0
+      // for all outcomes (successful or otherwise).
+      return status === 0 ||
+        (status >= 200 && status < 300);
+    },
+
+    /**
      * Sends an HTTP request to the server and returns the XHR object.
      *
      * @method request
@@ -141,8 +158,14 @@ iron-request can be used to perform XMLHttpRequests.
 
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4 && !this.aborted) {
+
+          if (!this.succeeded) {
+            this.rejectCompletes(new Error('The request failed with status code: ' + this.xhr.status));
+            return;
+          }
+
           this._setResponse(this.parseResponse());
-          this.resolveCompletes(this.response);
+          this.resolveCompletes(this);
         }
       }.bind(this));
 

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -49,7 +49,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         server = sinon.fakeServer.create();
         server.respondWith(
           'GET',
-          '/responds_to_get_with_json',
+          /\/responds_to_get_with_json.*/,
           [
             200,
             jsonResponseHeaders,
@@ -198,17 +198,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('is accessible as a readonly property', function(done) {
-          request.completes.then(function(response) {
-            expect(ajax.lastResponse).to.be.equal(response);
+          request.completes.then(function (request) {
+            expect(ajax.lastResponse).to.be.equal(request.response);
             done();
           }).catch(done);
         });
 
-        test('updates with each new response', function(done) {
-          request.completes.then(function(response) {
 
-            expect(response).to.be.an('object');
-            expect(ajax.lastResponse).to.be.equal(response);
+        test('updates with each new response', function(done) {
+          request.completes.then(function(request) {
+
+            expect(request.response).to.be.an('object');
+            expect(ajax.lastResponse).to.be.equal(request.response);
 
             ajax.handleAs = 'text';
             request = ajax.generateRequest();
@@ -216,10 +217,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             return request.completes;
 
-          }).then(function(response) {
+          }).then(function(request) {
 
-            expect(response).to.be.a('string');
-            expect(ajax.lastResponse).to.be.equal(response);
+            expect(request.response).to.be.a('string');
+            expect(ajax.lastResponse).to.be.equal(request.response);
 
             done();
 

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -28,7 +28,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     suite('<iron-request>', function () {
       var jsonResponseHeaders;
-      var requestOptions;
+      var successfulRequestOptions;
       var request;
       var server;
 
@@ -37,18 +37,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           'Content-Type': 'application/json'
         };
         server = sinon.fakeServer.create();
-        server.respondWith(
-          'GET',
-          '/responds_to_get_with_json',
-          [
-            200,
-            jsonResponseHeaders,
-            '{"success":true}'
-          ]
-        );
+        server.respondWith('GET', '/responds_to_get_with_json', [
+          200,
+          jsonResponseHeaders,
+          '{"success":true}'
+        ]);
+
+        server.respondWith('GET', '/responds_to_get_with_500', [
+          500,
+          {},
+          ''
+        ]);
+
+        server.respondWith('GET', '/responds_to_get_with_100', [
+          100,
+          {},
+          ''
+        ]);
+
+        server.respondWith('GET', '/responds_to_get_with_0', [
+          0,
+          jsonResponseHeaders,
+          '{"success":true}'
+        ]);
+
 
         request = fixture('TrivialRequest');
-        requestOptions = {
+        successfulRequestOptions = {
           url: '/responds_to_get_with_json'
         };
       });
@@ -59,7 +74,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('basic usage', function () {
         test('creates network requests, requiring only `url`', function () {
-          request.send(requestOptions);
+          request.send(successfulRequestOptions);
 
           server.respond();
 
@@ -67,12 +82,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('sets async to true by default', function () {
-          request.send(requestOptions);
+          request.send(successfulRequestOptions);
           expect(request.xhr.async).to.be.eql(true);
         });
 
         test('can be aborted', function (done) {
-          request.send(requestOptions);
+          request.send(successfulRequestOptions);
 
           request.abort();
 
@@ -84,6 +99,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(request.response).to.not.be.ok;
             done();
           });
+        });
+      });
+
+      suite('special cases', function() {
+        test('treats status code 0 as success, though the outcome is ambiguous', function() {
+          // Note: file:// status code will probably be 0 no matter what happened.
+          request.send({
+            url: '/responds_to_get_with_0'
+          });
+
+          server.respond();
+
+          expect(request.succeeded).to.be.equal(true);
+        });
+      });
+
+      suite('errors', function() {
+        test('treats status codes between 1 and 199 as errors', function() {
+          request.send({
+            url: '/responds_to_get_with_100'
+          });
+
+          server.respond();
+
+          expect(request.succeeded).to.be.equal(false);
+        });
+
+        test('treats status codes between 300 and ∞ as errors', function() {
+          request.send({
+            url: '/responds_to_get_with_500'
+          });
+
+          server.respond();
+
+          expect(request.succeeded).to.be.equal(false);
         });
       });
     });


### PR DESCRIPTION
 - Status codes between 1 and 199 are considered failures.
 - Status codes between 300 and Infinity are considered failures.
 - Status code 0 is considered successful, although it is ambiguous.
 - `request` event sends a pointer to the `IronRequest` instance, rather
   than the `xhr`.
 - `response` event sends a pointer to the `IronRequest` instance,
   rather than the `xhr` response content.

Addresses #11, #12, #13 & #16.