### PR TITLE
observes params in the `requestOptionsChanged` observer

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -19,7 +19,7 @@ The `iron-ajax` element exposes network request functionality.
         params='{"alt":"json", "q":"chrome"}'
         handle-as="json"
         on-response="handleResponse"
-        debounce-for="300"></iron-ajax>
+        debounce-duration="300"></iron-ajax>
 
 With `auto` set to `true`, the element performs a request whenever
 its `url`, `params` or `body` properties are changed. Automatically generated
@@ -242,12 +242,11 @@ element.
       /**
        * Length of time in milliseconds to debounce multiple requests.
        */
-      debounceFor: {
+      debounceDuration: {
         type: Number,
         value: 0,
         notify: true
       },
-
 
       _boundHandleResponse: {
         type: Function,
@@ -341,7 +340,7 @@ element.
         if (this.auto) {
           this.generateRequest();
         }
-      }, this.debounceFor);
+      }, this.debounceDuration);
     },
 
     /**

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -271,7 +271,7 @@ element.
     },
 
     observers: [
-      'requestOptionsChanged(url, method, headers,' +
+      'requestOptionsChanged(url, method, params, headers,' +
         'contentType, body, sync, handleAs, withCredentials, auto)'
     ],
 

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -18,7 +18,8 @@ The `iron-ajax` element exposes network request functionality.
         url="http://gdata.youtube.com/feeds/api/videos/"
         params='{"alt":"json", "q":"chrome"}'
         handle-as="json"
-        on-response="handleResponse"></iron-ajax>
+        on-response="handleResponse"
+        debounce-for="300"></iron-ajax>
 
 With `auto` set to `true`, the element performs a request whenever
 its `url`, `params` or `body` properties are changed. Automatically generated
@@ -238,6 +239,16 @@ element.
         }
       },
 
+      /**
+       * Length of time in milliseconds to debounce multiple requests.
+       */
+      debounceFor: {
+        type: Number,
+        value: 0,
+        notify: true
+      },
+
+
       _boundHandleResponse: {
         type: Function,
         value: function() {
@@ -330,7 +341,7 @@ element.
         if (this.auto) {
           this.generateRequest();
         }
-      });
+      }, this.debounceFor);
     },
 
     /**

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -36,6 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                  url="/responds_to_post_with_json"></iron-ajax>
     </template>
   </test-fixture>
+  <test-fixture id="DebouncedGet">
+    <template>
+      <iron-ajax auto
+                 url="/responds_to_debounced_get_with_json"
+                 debounce-duration="150"></iron-ajax>
+    </template>
+  </test-fixture>
   <script>
     suite('<iron-ajax>', function () {
       var responseHeaders = {
@@ -75,6 +82,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             200,
             responseHeaders.plain,
             'Hello World'
+          ]
+        );
+
+        server.respondWith(
+          'GET',
+          '/responds_to_debounced_get_with_json',
+          [
+            200,
+            responseHeaders.json,
+            '{"success": "true"}'
           ]
         );
 
@@ -255,6 +272,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      suite('when debouncing requests', function() {
+        setup(function() {
+          ajax = fixture('DebouncedGet');
+        });
+
+        test('only requests a single resource', function(done) {
+          ajax.requestOptionsChanged();
+          expect(server.requests[0]).to.be.equal(undefined);
+          ajax.requestOptionsChanged();
+          window.setTimeout(function() {
+            expect(server.requests[0]).to.be.ok;
+            done();
+          }, 200);
+        });
+      });
+
       suite('when a response handler is bound', function() {
         var responseHandler;
 
@@ -294,7 +327,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('when handleAs parameter is `text`', function() {
-       
+
         test('response type is string', function (done) {
 
           ajax.url = '/responds_to_get_with_json';
@@ -315,7 +348,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('when handleAs parameter is `json`', function() {
-       
+
         test('response type is string', function (done) {
 
           ajax.url = '/responds_to_get_with_json';

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -25,6 +25,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-ajax url="/responds_to_get_with_json"></iron-ajax>
     </template>
   </test-fixture>
+  <test-fixture id="ParamsGet">
+    <template>
+      <iron-ajax url="/responds_to_get_with_json"
+                 params='{"a": "a"}'></iron-ajax>
+    </template>
+  </test-fixture>
   <test-fixture id="AutoGet">
     <template>
       <iron-ajax auto url="/responds_to_get_with_json"></iron-ajax>
@@ -172,6 +178,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('holds all requests in the `activeRequests` Array', function() {
           expect(requests).to.deep.eql(ajax.activeRequests);
+        });
+      });
+
+      suite('when params are changed', function() {
+        test('generates a request that reflects the change', function() {
+          ajax = fixture('ParamsGet');
+          request = ajax.generateRequest();
+
+          expect(request.xhr.url).to.be.equal('/responds_to_get_with_json?a=a');
+
+          ajax.params = {b: 'b'};
+          request = ajax.generateRequest();
+
+          expect(request.xhr.url).to.be.equal('/responds_to_get_with_json?b=b');
         });
       });
 


### PR DESCRIPTION
This is currently based off of my master because I forgot to branch for the previous PR (-_-), so it includes the commits for that PR as well.

I can close the [previous PR](https://github.com/PolymerElements/iron-ajax/pull/24), move the code to its own branch and re-pull-request, rebasing this branch on `PolymerElements/iron-ajax#master`, or this one could be merged after the other PR, whichever y'all would prefer.