### PR TITLE
Address several bugs, improve docs

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -30,6 +30,8 @@ Note: The `params` attribute must be double quoted JSON.
 
 You can trigger a request explicitly by calling `generateRequest` on the
 element.
+
+@demo demo/index.html
 -->
 
 <script>
@@ -67,7 +69,9 @@ element.
 
       /**
        * An object that contains query parameters to be appended to the
-       * specified `url` when generating a request.
+       * specified `url` when generating a request. If you wish to set the body
+       * content when making a POST request, you should use the `body` property
+       * instead.
        */
       params: {
         type: Object,
@@ -96,6 +100,9 @@ element.
        *         headers='{"X-Requested-With": "XMLHttpRequest"}'
        *         handle-as="json"
        *         last-response-changed="{{handleResponse}}"></iron-ajax>
+       *
+       * Note: setting a `Content-Type` header here will override the value
+       * specified by the `contentType` property of this element.
        */
       headers: {
         type: Object,
@@ -105,9 +112,9 @@ element.
       },
 
       /**
-       * Content type to use when sending data. If the contenttype is set
-       * and a `Content-Type` header is specified in the `headers` attribute,
-       * the `headers` attribute value will take precedence.
+       * Content type to use when sending data. If the `contentType` property
+       * is set and a `Content-Type` header is specified in the `headers`
+       * property, the `headers` property value will take precedence.
        */
       contentType: {
         type: String,
@@ -207,7 +214,7 @@ element.
       /**
        * Will be set to the most recent response received by a request
        * that originated from this iron-ajax element. The type of the response
-       * is determined by the value of `handleas` at the time that the request
+       * is determined by the value of `handleAs` at the time that the request
        * was generated.
        */
       lastResponse: {
@@ -251,23 +258,22 @@ element.
       _boundHandleResponse: {
         type: Function,
         value: function() {
-          return this.handleResponse.bind(this);
-        }
-      },
-
-      _boundDiscardRequest: {
-        type: Function,
-        value: function() {
-          return this.discardRequest.bind(this);
+          return this._handleResponse.bind(this);
         }
       }
     },
 
     observers: [
-      'requestOptionsChanged(url, method, params, headers,' +
+      '_requestOptionsChanged(url, method, params, headers,' +
         'contentType, body, sync, handleAs, withCredentials, auto)'
     ],
 
+    /**
+     * The query string that should be appended to the `url`, serialized from
+     * the current value of `params`.
+     *
+     * @return {string}
+     */
     get queryString () {
       var queryParts = [];
       var param;
@@ -287,6 +293,12 @@ element.
       return queryParts.join('&');
     },
 
+    /**
+     * The `url` with query string (if `params` are specified), suitable for
+     * providing to an `iron-request` instance.
+     *
+     * @return {string}
+     */
     get requestUrl() {
       var queryString = this.queryString;
 
@@ -297,9 +309,16 @@ element.
       return this.url;
     },
 
+    /**
+     * An object that maps header names to header values, first applying the
+     * the value of `Content-Type` and then overlaying the headers specified
+     * in the `headers` property.
+     *
+     * @return {Object}
+     */
     get requestHeaders() {
       var headers = {
-        'content-type': this.contentType
+        'Content-Type': this.contentType
       };
       var header;
 
@@ -312,6 +331,12 @@ element.
       return headers;
     },
 
+    /**
+     * Request options suitable for generating an `iron-request` instance based
+     * on the current state of the `iron-ajax` instance's properties.
+     *
+     * @return {Object}
+     */
     toRequestOptions: function() {
       return {
         url: this.requestUrl,
@@ -324,22 +349,10 @@ element.
       };
     },
 
-    requestOptionsChanged: function() {
-      this.debounce('generate-request', function() {
-        if (!this.url && this.url !== '') {
-          return;
-        }
-
-        if (this.auto) {
-          this.generateRequest();
-        }
-      }, this.debounceDuration);
-    },
-
     /**
      * Performs an AJAX request to the specified URL.
      *
-     * @method generateRequest
+     * @return {iron-request}
      */
     generateRequest: function() {
       var request = document.createElement('iron-request');
@@ -350,14 +363,15 @@ element.
       request.completes.then(
         this._boundHandleResponse
       ).catch(
-        this.handleError.bind(this, request)
+        this._handleError.bind(this, request)
       ).then(
-        this._boundDiscardRequest
+        this._discardRequest.bind(this, request)
       );
 
       request.send(requestOptions);
 
       this._setLastRequest(request);
+      this._setLoading(true);
 
       this.fire('request', {
         request: request,
@@ -367,12 +381,12 @@ element.
       return request;
     },
 
-    handleResponse: function(request) {
+    _handleResponse: function(request) {
       this._setLastResponse(request.response);
       this.fire('response', request);
     },
 
-    handleError: function(request, error) {
+    _handleError: function(request, error) {
       if (this.verbose) {
         console.error(error);
       }
@@ -387,12 +401,29 @@ element.
       });
     },
 
-    discardRequest: function(request) {
+    _discardRequest: function(request) {
       var requestIndex = this.activeRequests.indexOf(request);
 
-      if (requestIndex > 0) {
+      if (requestIndex > -1) {
         this.activeRequests.splice(requestIndex, 1);
       }
-    }
+
+      if (this.activeRequests.length === 0) {
+        this._setLoading(false);
+      }
+    },
+
+    _requestOptionsChanged: function() {
+      this.debounce('generate-request', function() {
+        if (!this.url && this.url !== '') {
+          return;
+        }
+
+        if (this.auto) {
+          this.generateRequest();
+        }
+      }, this.debounceDuration);
+    },
+
   });
 </script>

--- a/iron-request.html
+++ b/iron-request.html
@@ -115,7 +115,7 @@ iron-request can be used to perform XMLHttpRequests.
      * the status code 0 is accepted as a success even though the outcome may
      * be ambiguous.
      *
-     * @return boolean
+     * @return {boolean}
      */
     get succeeded() {
       var status = this.xhr.status || 0;
@@ -129,7 +129,6 @@ iron-request can be used to perform XMLHttpRequests.
     /**
      * Sends an HTTP request to the server and returns the XHR object.
      *
-     * @method request
      * @param {{
      *   url: string,
      *   method: (string|undefined),
@@ -146,7 +145,7 @@ iron-request can be used to perform XMLHttpRequests.
      *     headers HTTP request headers.
      *     handleAs The response type. Default is 'text'.
      *     withCredentials Whether or not to send credentials on the request. Default is false.
-     * @return Promise
+     * @return {Promise}
      */
     send: function (options) {
       var xhr = this.xhr;
@@ -209,6 +208,14 @@ iron-request can be used to perform XMLHttpRequests.
       return this.completes;
     },
 
+    /**
+     * Attempts to parse the response body of the XHR. If parsing succeeds,
+     * the value returned will be deserialized based on the `responseType`
+     * set on the XHR.
+     *
+     * @return {Object|Array|Document|string|undefined} The parsed response,
+     * or undefined if there was an empty response or parsing failed.
+     */
     parseResponse: function () {
       var xhr = this.xhr;
       var responseType = this.xhr.responseType ||
@@ -253,6 +260,9 @@ iron-request can be used to perform XMLHttpRequests.
       }
     },
 
+    /**
+     * Aborts the request.
+     */
     abort: function () {
       this._setAborted(true);
       this.xhr.abort();

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../promise-polyfill/promise-polyfill-lite.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-ajax.html">
 </head>
@@ -58,6 +59,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var ajax;
       var request;
       var server;
+
+      function timePasses(ms) {
+        return new Promise(function(resolve) {
+          window.setTimeout(function() {
+            resolve();
+          }, ms);
+        });
+      }
 
       setup(function() {
         server = sinon.fakeServer.create();
@@ -158,10 +167,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('when generating a request', function() {
-        test('yields a iron-request instance', function() {
+        test('yields an iron-request instance', function() {
           var IronRequest = document.createElement('iron-request').constructor;
 
           expect(ajax.generateRequest()).to.be.instanceOf(IronRequest);
+        });
+
+        test('reflects the loading state in the `loading` property', function(done) {
+          var request = ajax.generateRequest();
+
+          expect(ajax.loading).to.be.equal(true);
+
+          server.respond();
+
+          timePasses(1).then(function() {
+            expect(ajax.loading).to.be.equal(false);
+            done();
+          }).catch(function(e) {
+            done(e);
+          });
         });
       });
 
@@ -178,6 +202,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('holds all requests in the `activeRequests` Array', function() {
           expect(requests).to.deep.eql(ajax.activeRequests);
+        });
+
+        test('empties `activeRequests` when requests are completed', function(done) {
+          server.respond();
+          timePasses(1).then(function() {
+            expect(ajax.activeRequests.length).to.be.equal(0);
+            done();
+          }).catch(function(e) {
+            done(e);
+          });
         });
       });
 
@@ -298,9 +332,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('only requests a single resource', function(done) {
-          ajax.requestOptionsChanged();
+          ajax._requestOptionsChanged();
           expect(server.requests[0]).to.be.equal(undefined);
-          ajax.requestOptionsChanged();
+          ajax._requestOptionsChanged();
           window.setTimeout(function() {
             expect(server.requests[0]).to.be.ok;
             done();


### PR DESCRIPTION
 - A bug that caused `activeRequests` to hold references to all requests
   made has been resolved.
 - The `loading` property now reflects the loading state of `iron-ajax`.
 - Many docs have been added or updated for `iron-ajax` and `iron-request`
 - Some regression tests have been added for the above bugs.

Addresses #30, #36 and #40 

/cc @notwaldorf 