### PR TITLE
Skip a request if the url is an empty string (the default).

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -415,7 +415,7 @@ element.
 
     _requestOptionsChanged: function() {
       this.debounce('generate-request', function() {
-        if (!this.url && this.url !== '') {
+        if (!this.url && this.url == '') {
           return;
         }
 


### PR DESCRIPTION
I have been having an issue where trying to use `auto` with a `url` that is a computed binding causes `iron-ajax` to issue an immediate request before the computed binding is actually set. At this point `url` is the default empty string and thus issues a request to the root of the domain. Fractions of a second later the binding is set and the actual request we wanted is triggered.

I thought about it and realized the simple fix was to just not issue requests if the url was empty. However, looking at 1.0.1's code I see there is some code in there for that purpose. However, I think the logic has a mistake that causes it to not actually work.

The current logic:

    !this.url && this.url !== ''

simplifies to this in the case that `url` is actually an empty string:

    !'' && '' !== ''

So the first `!` on `this.url` when it's empty results as `true`, so then JS assesses the second half, which as you see will always be `false` because an empty string is never not equal to an empty string. This then becomes `false && true` which is always `false`, meaning the `if`'s body is never ran and an empty string as a URL makes it through to request.

This pull request just removes the `!`, which in our case of an empty string becomes this expression:

    !'' && '' == ''
    true && true

And thus the `if`'s body is ran and we return without making the request.
