### PR TITLE
Fix example

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -98,8 +98,7 @@ element.
        *         auto
        *         url="http://somesite.com"
        *         headers='{"X-Requested-With": "XMLHttpRequest"}'
-       *         handle-as="json"
-       *         last-response-changed="{{handleResponse}}"></iron-ajax>
+       *         handle-as="json"></iron-ajax>
        *
        * Note: setting a `Content-Type` header here will override the value
        * specified by the `contentType` property of this element.


### PR DESCRIPTION
Remove `last-response-changed` from the `headers` example as it is no longer valid for Polymer 1.0 and unnecessary for the example.