### PR TITLE
Added status code and status text to the request object.

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -304,7 +304,7 @@ iron-request can be used to perform XMLHttpRequests.
      */
     _updateStatus: function() {
       this._setStatus(this.xhr.status);
-      this._setStatusText(this.xhr.statusText);
+      this._setStatusText((this.xhr.statusText === undefined) ? '' : this.xhr.statusText);
     }
   });
 </script>

--- a/iron-request.html
+++ b/iron-request.html
@@ -58,6 +58,34 @@ iron-request can be used to perform XMLHttpRequests.
       },
 
       /**
+       * A reference to the status code, if the `xhr` has completely resolved.
+       *
+       * @attribute status
+       * @type short
+       * @default 0
+       */
+      status: {
+        type: Number,
+        notify: true,
+        readOnly: true,
+        value: 0
+      },
+
+      /**
+       * A reference to the status text, if the `xhr` has completely resolved.
+       *
+       * @attribute statusText
+       * @type String
+       * @default ""
+       */
+      statusText: {
+        type: String,
+        notify: true,
+        readOnly: true,
+        value: ''
+      },
+
+      /**
        * A promise that resolves when the `xhr` response comes back, or rejects
        * if there is an error before the `xhr` completes.
        *
@@ -156,6 +184,7 @@ iron-request can be used to perform XMLHttpRequests.
 
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4 && !this.aborted) {
+          this._updateStatus();
 
           if (!this.succeeded) {
             this.rejectCompletes(new Error('The request failed with status code: ' + this.xhr.status));
@@ -176,10 +205,12 @@ iron-request can be used to perform XMLHttpRequests.
       }.bind(this))
 
       xhr.addEventListener('error', function (error) {
+        this._updateStatus();
         this.rejectCompletes(error);
       }.bind(this));
 
       xhr.addEventListener('abort', function () {
+        this._updateStatus();
         this.rejectCompletes(new Error('Request aborted.'));
       }.bind(this));
 
@@ -266,6 +297,14 @@ iron-request can be used to perform XMLHttpRequests.
     abort: function () {
       this._setAborted(true);
       this.xhr.abort();
+    },
+
+    /**
+     * Updates the status code and status text.
+     */
+    _updateStatus: function() {
+      this._setStatus(this.xhr.status);
+      this._setStatusText(this.xhr.statusText);
     }
   });
 </script>

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -168,6 +168,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(request.succeeded).to.be.equal(false);
         });
       });
+
+      suite('status codes', function() {
+        test('status and statusText is set after a ambiguous request', function() {
+          request.send({
+            url: '/responds_to_get_with_0'
+          });
+
+          server.respond();
+          console.log(request.statusText);
+          expect(request.status).to.be.equal(0);
+          expect(request.statusText).to.be.equal('');
+        });
+
+        test('status and statusText is set after a request that succeeded', function() {
+          request.send({
+            url: '/responds_to_get_with_json'
+          });
+
+          server.respond();
+
+          expect(request.status).to.be.equal(200);
+          expect(request.statusText).to.be.equal('OK');
+        });
+
+        test('status and statusText is set after a request that failed', function() {
+          request.send({
+            url: '/responds_to_get_with_500'
+          });
+
+          server.respond();
+
+          expect(request.status).to.be.equal(500);
+          expect(request.statusText).to.be.equal('Internal Server Error');
+        });
+      });
     });
   </script>
 

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -176,7 +176,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           server.respond();
-          console.log(request.statusText);
+          
           expect(request.status).to.be.equal(0);
           expect(request.statusText).to.be.equal('');
         });


### PR DESCRIPTION
When using the iron-ajax element I was expecting it to handle everything including the request detail for the AJAX request. Digging into the XMLHttpRequest object inside the iron-request element seems dirty. I wanted to bring the status and statusText up to the iron-request element level.