### PR TITLE
Automatic encoding for `this.body` when it's an Object.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -36,6 +36,7 @@ element.
 -->
 
 <script>
+  'use strict';
 
   Polymer({
 
@@ -125,37 +126,18 @@ element.
        * Body content to send with the request, typically used with "POST"
        * requests.
        *
-       * If body is a string it will be sent up raw with the request.
+       * If body is a string it will be sent unmodified.
        *
-       * If body is a plain object and no Content-Type is set, the object
-       * will be form encoded before sending.
+       * If Content-Type is set to a value listed below, then
+       * the body will be encoded accordingly.
        *
-       * If Content-Type is set and iron-request knows how, the body will be
-       * encoded according to that Content-Type. Content-Types known:
-       *    * application/json
-       *    * application/x-www-form-urlencoded
+       *    * `content-type="application/json"`
+       *      * body is encoded like `{"foo":"bar baz","x":1}`
+       *    * `content-type="application/x-www-form-urlencoded"`
+       *      * body is encoded like `foo=bar+baz&x=1`
        *
-       * Otherwise the body will be sent up raw, and the browser will handle
-       * any encoding (e.g. for FormData, Blob, ArrayBuffer, etc).
-       *
-       * Examples:
-       *
-       *     <iron-ajax method="POST" auto url="http://example.com"
-       *         body='{"foo": "bar"}'>
-       *     </iron-ajax>
-       * The body of the request will be `foo=bar` and the Content-Type
-       * will be `application/x-www-form-urlencoded`
-       *
-       *     <iron-ajax method="POST" auto url="http://example.com"
-       *         content-type="application/json"
-       *         body='{"foo": "bar"}'>
-       *     </iron-ajax>
-       * The body of the request will be `{"foo":"bar"}`.
-       *
-       *     <iron-ajax method="POST" auto url="http://example.com"
-       *         body='foobarbaz'>
-       *     </iron-ajax>
-       * The body will be sent up unmodified as `foobarbaz`.
+       * Otherwise the body will be passed to the browser unmodified, and it
+       * will handle any encoding (e.g. for FormData, Blob, ArrayBuffer).
        *
        * @type (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object)
        */

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -122,18 +122,46 @@ element.
       },
 
       /**
-       * Optional raw body content to send when method === "POST".
+       * Body content to send with the request, typically used with "POST"
+       * requests.
        *
-       * Example:
+       * If body is a string it will be sent up raw with the request.
        *
-       *     <iron-ajax method="POST" auto url="http://somesite.com"
-       *         content-type="application/json"
-       *         body='{"foo":1, "bar":2}'>
+       * If body is a plain object and no Content-Type is set, the object
+       * will be form encoded before sending.
+       *
+       * If Content-Type is set and iron-request knows how, the body will be
+       * encoded according to that Content-Type. Content-Types known:
+       *    * application/json
+       *    * application/x-www-form-urlencoded
+       *
+       * Otherwise the body will be sent up raw, and the browser will handle
+       * any encoding (e.g. for FormData, Blob, ArrayBuffer, etc).
+       *
+       * Examples:
+       *
+       *     <iron-ajax method="POST" auto url="http://example.com"
+       *         body='{"foo": "bar"}'>
        *     </iron-ajax>
+       * The body of the request will be `foo=bar` and the Content-Type
+       * will be `application/x-www-form-urlencoded`
+       *
+       *     <iron-ajax method="POST" auto url="http://example.com"
+       *         content-type="application/json"
+       *         body='{"foo": "bar"}'>
+       *     </iron-ajax>
+       * The body of the request will be `{"foo":"bar"}`.
+       *
+       *     <iron-ajax method="POST" auto url="http://example.com"
+       *         body='foobarbaz'>
+       *     </iron-ajax>
+       * The body will be sent up unmodified as `foobarbaz`.
+       *
+       * @type (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object)
        */
       body: {
-        type: String,
-        value: ''
+        type: Object,
+        value: null
       },
 
       /**

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -345,7 +345,7 @@ element.
      *   url: string,
      *   method: (string|undefined),
      *   async: (boolean|undefined),
-     *   body: (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined),
+     *   body: (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object),
      *   headers: (Object|undefined),
      *   handleAs: (string|undefined),
      *   withCredentials: (boolean|undefined)}}

--- a/iron-request.html
+++ b/iron-request.html
@@ -161,7 +161,7 @@ iron-request can be used to perform XMLHttpRequests.
      *   url: string,
      *   method: (string|undefined),
      *   async: (boolean|undefined),
-     *   body: (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined),
+     *   body: (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object),
      *   headers: (Object|undefined),
      *   handleAs: (string|undefined),
      *   withCredentials: (boolean|undefined)}} options -
@@ -229,12 +229,21 @@ iron-request can be used to perform XMLHttpRequests.
         }, this);
       }
 
+      var contentType;
+      if (options.headers) {
+        contentType = options.headers['Content-Type'];
+      }
+      body = this._encodeBodyObject(options.body, contentType);
+
+
       // In IE, `xhr.responseType` is an empty string when the response
       // returns. Hence, caching it as `xhr._responseType`.
       xhr.responseType = xhr._responseType = (options.handleAs || 'text');
       xhr.withCredentials = !!options.withCredentials;
 
-      xhr.send(options.body);
+
+
+      xhr.send(body);
 
       return this.completes;
     },
@@ -297,6 +306,80 @@ iron-request can be used to perform XMLHttpRequests.
     abort: function () {
       this._setAborted(true);
       this.xhr.abort();
+    },
+
+    /**
+     * @param {*} body The given body of the request to try and encode.
+     * @param {?string} contentType The given content type, to infer an encoding
+     *     from.
+     * @return {?string|Object} Either the encoded body as a string, if
+     *     successful, or the unaltered body object, if no encoding could be
+     *     inferred.
+     */
+    _encodeBodyObject: function(body, contentType) {
+      if (typeof body == 'string') {
+        return body;  // Already encoded.
+      }
+      switch(contentType) {
+        case('application/json'):
+          return JSON.stringify(body);
+        case('application/x-www-form-urlencoded'):
+          return this._wwwFormUrlEncode(body);
+        case(null):  // fall through
+        case(undefined):
+          // More complex objects may be natively understood by the browser,
+          // e.g. ArrayBuffer, FormData, Document.
+          // If the user wants a non-plain object to be form encoded they'll
+          // need to specify the content type manually, we shouldn't try to
+          // infer it.
+          if (this._isPlainObject(body)) {
+            return this._wwwFormUrlEncode(body);
+          }
+          // fall through
+        default:
+      }
+      return body;  // Unknown, make no change.
+    },
+
+    /**
+     * @param {Object} obj The object to encode in x-www-form-urlencoded format.
+     * @return {string} .
+     */
+    _wwwFormUrlEncode: function(obj) {
+      if (!obj) {
+        return '';
+      }
+      var pieces = [];
+      Object.keys(obj).forEach(function(key) {
+        // TODO(rictic): handle array values here, in a consistent way with
+        //   iron-ajax params.
+        pieces.push(
+            this._wwwFormUrlEncodePiece(key) + '=' +
+            this._wwwFormUrlEncodePiece(obj[key]));
+      }, this);
+      return pieces.join('&');
+    },
+
+    /**
+     * @param {*} str A key/value to encode in x-www-form-urlencoded format.
+     * @param {string} .
+     */
+    _wwwFormUrlEncodePiece: function(str) {
+      // Spec says to normalize newlines to \r\n and replace %20 spaces with +.
+      // jQuery does this as well, so this is likely to be widely compatible.
+      return encodeURIComponent(str.toString().replace(/\r?\n/g, '\r\n'))
+          .replace(/%20/g, '+');
+    },
+
+    /**
+     * @param {*} ob Any value.
+     * @return {boolean} True iff `ob` is a direct descendent of Object.
+     */
+    _isPlainObject: function(ob) {
+      // If it's not null, and it's an instance of Object, and its constructor's
+      // prototype is the source of the definition of 'hasOwnProperty', then
+      // it's probably a direct instance of Object.
+      return ob && (ob instanceof Object) && ob.constructor && ob.constructor.prototype && ob.constructor.prototype.hasOwnProperty('hasOwnProperty');
     },
 
     /**

--- a/iron-request.html
+++ b/iron-request.html
@@ -18,6 +18,8 @@ iron-request can be used to perform XMLHttpRequests.
     this.$.xhr.send({url: url, params: params});
 -->
 <script>
+  'use strict'
+
   Polymer({
     is: 'iron-request',
 
@@ -233,7 +235,7 @@ iron-request can be used to perform XMLHttpRequests.
       if (options.headers) {
         contentType = options.headers['Content-Type'];
       }
-      body = this._encodeBodyObject(options.body, contentType);
+      var body = this._encodeBodyObject(options.body, contentType);
 
 
       // In IE, `xhr.responseType` is an empty string when the response
@@ -312,9 +314,8 @@ iron-request can be used to perform XMLHttpRequests.
      * @param {*} body The given body of the request to try and encode.
      * @param {?string} contentType The given content type, to infer an encoding
      *     from.
-     * @return {?string|Object} Either the encoded body as a string, if
-     *     successful, or the unaltered body object, if no encoding could be
-     *     inferred.
+     * @return {?string|*} Either the encoded body as a string, if successful,
+     *     or the unaltered body object if no encoding could be inferred.
      */
     _encodeBodyObject: function(body, contentType) {
       if (typeof body == 'string') {
@@ -325,63 +326,38 @@ iron-request can be used to perform XMLHttpRequests.
           return JSON.stringify(body);
         case('application/x-www-form-urlencoded'):
           return this._wwwFormUrlEncode(body);
-        case(null):  // fall through
-        case(undefined):
-          // More complex objects may be natively understood by the browser,
-          // e.g. ArrayBuffer, FormData, Document.
-          // If the user wants a non-plain object to be form encoded they'll
-          // need to specify the content type manually, we shouldn't try to
-          // infer it.
-          if (this._isPlainObject(body)) {
-            return this._wwwFormUrlEncode(body);
-          }
-          // fall through
-        default:
       }
       return body;  // Unknown, make no change.
     },
 
     /**
-     * @param {Object} obj The object to encode in x-www-form-urlencoded format.
+     * @param {Object} object The object to encode as x-www-form-urlencoded.
      * @return {string} .
      */
-    _wwwFormUrlEncode: function(obj) {
-      if (!obj) {
+    _wwwFormUrlEncode: function(object) {
+      if (!object) {
         return '';
       }
       var pieces = [];
-      Object.keys(obj).forEach(function(key) {
+      Object.keys(object).forEach(function(key) {
         // TODO(rictic): handle array values here, in a consistent way with
         //   iron-ajax params.
         pieces.push(
             this._wwwFormUrlEncodePiece(key) + '=' +
-            this._wwwFormUrlEncodePiece(obj[key]));
+            this._wwwFormUrlEncodePiece(object[key]));
       }, this);
       return pieces.join('&');
     },
 
     /**
-     * @param {*} str A key/value to encode in x-www-form-urlencoded format.
-     * @param {string} .
+     * @param {*} str A key or value to encode as x-www-form-urlencoded.
+     * @return {string} .
      */
     _wwwFormUrlEncodePiece: function(str) {
       // Spec says to normalize newlines to \r\n and replace %20 spaces with +.
       // jQuery does this as well, so this is likely to be widely compatible.
       return encodeURIComponent(str.toString().replace(/\r?\n/g, '\r\n'))
           .replace(/%20/g, '+');
-    },
-
-    /**
-     * @param {*} ob Any value.
-     * @return {boolean} True iff `ob` is a direct descendent of Object.
-     */
-    _isPlainObject: function(ob) {
-      // If it's not null, and it's an instance of Object, and its constructor's
-      // prototype is the source of the definition of 'hasOwnProperty', then
-      // it's probably a direct instance of Object.
-      return ob && (ob instanceof Object) && ob.constructor &&
-          ob.constructor.prototype &&
-          ob.constructor.prototype.hasOwnProperty('hasOwnProperty');
     },
 
     /**

--- a/iron-request.html
+++ b/iron-request.html
@@ -379,7 +379,9 @@ iron-request can be used to perform XMLHttpRequests.
       // If it's not null, and it's an instance of Object, and its constructor's
       // prototype is the source of the definition of 'hasOwnProperty', then
       // it's probably a direct instance of Object.
-      return ob && (ob instanceof Object) && ob.constructor && ob.constructor.prototype && ob.constructor.prototype.hasOwnProperty('hasOwnProperty');
+      return ob && (ob instanceof Object) && ob.constructor &&
+          ob.constructor.prototype &&
+          ob.constructor.prototype.hasOwnProperty('hasOwnProperty');
     },
 
     /**

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -151,14 +151,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           expect(options.headers).to.be.ok;
           expect(options.headers['custom-header']).to.be.an('string');
-          expect(options.headers.hasOwnProperty('custom-header')).to.be.equal(true);
+          expect(options.headers.hasOwnProperty('custom-header')).to.be.equal(
+              true);
         });
 
         test('non-objects in headers are not applied', function() {
           ajax.headers = 'invalid';
           var options = ajax.toRequestOptions();
 
-          expect(Object.keys(options.headers).length).to.be.equal(1);
+          expect(Object.keys(options.headers).length).to.be.equal(0);
         });
       });
 
@@ -373,6 +374,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           );
         });
+
+        suite('the examples in the documentation work', function() {
+          test('no content-type, body attribute is an object', function() {
+            ajax.setAttribute('body', '{"foo": "bar"}');
+            ajax.generateRequest();
+
+            expect(server.requests[0]).to.be.ok;
+            expect(server.requests[0].requestBody).to.be.equal(
+                'foo=bar');
+          });
+
+          test('json content, body attribute is an object', function() {
+            ajax.setAttribute('body', '{"foo": "bar"}');
+            ajax.contentType = 'application/json';
+            ajax.generateRequest();
+
+            expect(server.requests[0]).to.be.ok;
+            expect(server.requests[0].requestBody).to.be.equal(
+                '{"foo":"bar"}');
+          });
+
+          test('form encoded content as a string', function() {
+            ajax.setAttribute('body', 'foobarbaz');
+            ajax.generateRequest();
+
+            expect(server.requests[0]).to.be.ok;
+            expect(server.requests[0].requestBody).to.be.equal(
+                'foobarbaz');
+          });
+        })
 
         suite('and `contentType` is explicitly set to form encode', function() {
           test('we encode a custom object', function() {

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -337,73 +337,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(server.requests[0].requestBody).to.be.equal(requestBody);
         });
 
-        suite('and `body` is a plain Object', function() {
-          test('if `contentType` isn\'t set, the body is form encoded',
-            function() {
-              ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
-              ajax.generateRequest();
+        test('if `contentType` is set to form encode, the body is encoded',function() {
+          ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
+          ajax.contentType = 'application/x-www-form-urlencoded';
+          ajax.generateRequest();
 
-              expect(server.requests[0]).to.be.ok;
-              expect(server.requests[0].requestBody).to.be.equal(
-                  'foo=bar%0D%0Abip&biz+bo=baz+blar');
-            }
-          );
+          expect(server.requests[0]).to.be.ok;
+          expect(server.requests[0].requestBody).to.be.equal(
+              'foo=bar%0D%0Abip&biz+bo=baz+blar');
+        });
 
-          test('if `contentType` is set to form encode, the body is encoded',
-            function() {
-              ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
-              ajax.contentType = 'application/x-www-form-urlencoded';
-              ajax.generateRequest();
+        test('if `contentType` is json, the body is json encoded', function() {
+          var requestObj = {foo: 'bar', baz: [1,2,3]}
+          ajax.body = requestObj;
+          ajax.contentType = 'application/json';
+          ajax.generateRequest();
 
-              expect(server.requests[0]).to.be.ok;
-              expect(server.requests[0].requestBody).to.be.equal(
-                  'foo=bar%0D%0Abip&biz+bo=baz+blar');
-            }
-          );
-
-          test('if `contentType` is json, the body is json encoded',
-            function() {
-              var requestObj = {foo: 'bar', baz: [1,2,3]}
-              ajax.body = requestObj;
-              ajax.contentType = 'application/json';
-              ajax.generateRequest();
-
-              expect(server.requests[0]).to.be.ok;
-              expect(server.requests[0].requestBody).to.be.equal(
-                  JSON.stringify(requestObj));
-            }
-          );
+          expect(server.requests[0]).to.be.ok;
+          expect(server.requests[0].requestBody).to.be.equal(
+              JSON.stringify(requestObj));
         });
 
         suite('the examples in the documentation work', function() {
-          test('no content-type, body attribute is an object', function() {
-            ajax.setAttribute('body', '{"foo": "bar"}');
-            ajax.generateRequest();
-
-            expect(server.requests[0]).to.be.ok;
-            expect(server.requests[0].requestBody).to.be.equal(
-                'foo=bar');
-          });
-
           test('json content, body attribute is an object', function() {
-            ajax.setAttribute('body', '{"foo": "bar"}');
+            ajax.setAttribute('body', '{"foo": "bar baz", "x": 1}');
             ajax.contentType = 'application/json';
             ajax.generateRequest();
 
             expect(server.requests[0]).to.be.ok;
             expect(server.requests[0].requestBody).to.be.equal(
-                '{"foo":"bar"}');
+                '{"foo":"bar baz","x":1}');
           });
 
-          test('form encoded content as a string', function() {
-            ajax.setAttribute('body', 'foobarbaz');
+          test('form content, body attribute is an object', function() {
+            ajax.setAttribute('body', '{"foo": "bar baz", "x": 1}');
+            ajax.contentType = 'application/x-www-form-urlencoded';
             ajax.generateRequest();
 
             expect(server.requests[0]).to.be.ok;
             expect(server.requests[0].requestBody).to.be.equal(
-                'foobarbaz');
+                'foo=bar+baz&x=1');
           });
-        })
+        });
 
         suite('and `contentType` is explicitly set to form encode', function() {
           test('we encode a custom object', function() {

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -324,7 +324,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       suite('when making POST requests', function() {
         setup(function() {
           ajax = fixture('TrivialPost');
-          realAjax = fixture('RealPost');
         });
 
         test('POSTs the value of the `body` attribute', function() {
@@ -336,6 +335,70 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(server.requests[0]).to.be.ok;
           expect(server.requests[0].requestBody).to.be.equal(requestBody);
         });
+
+        suite('and `body` is a plain Object', function() {
+          test('if `contentType` isn\'t set, the body is form encoded',
+            function() {
+              ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
+              ajax.generateRequest();
+
+              expect(server.requests[0]).to.be.ok;
+              expect(server.requests[0].requestBody).to.be.equal(
+                  'foo=bar%0D%0Abip&biz+bo=baz+blar');
+            }
+          );
+
+          test('if `contentType` is set to form encode, the body is encoded',
+            function() {
+              ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
+              ajax.contentType = 'application/x-www-form-urlencoded';
+              ajax.generateRequest();
+
+              expect(server.requests[0]).to.be.ok;
+              expect(server.requests[0].requestBody).to.be.equal(
+                  'foo=bar%0D%0Abip&biz+bo=baz+blar');
+            }
+          );
+
+          test('if `contentType` is json, the body is json encoded',
+            function() {
+              var requestObj = {foo: 'bar', baz: [1,2,3]}
+              ajax.body = requestObj;
+              ajax.contentType = 'application/json';
+              ajax.generateRequest();
+
+              expect(server.requests[0]).to.be.ok;
+              expect(server.requests[0].requestBody).to.be.equal(
+                  JSON.stringify(requestObj));
+            }
+          );
+        });
+
+        suite('and `contentType` is explicitly set to form encode', function() {
+          test('we encode a custom object', function() {
+            function Foo(bar) { this.bar = bar };
+            var requestObj = new Foo('baz');
+            ajax.body = requestObj;
+            ajax.contentType = 'application/x-www-form-urlencoded';
+            ajax.generateRequest();
+
+            expect(server.requests[0]).to.be.ok;
+            expect(server.requests[0].requestBody).to.be.equal('bar=baz');
+          });
+        })
+
+        suite('and `contentType` isn\'t set', function() {
+          test('we don\'t try to encode an ArrayBuffer', function() {
+            var requestObj = new ArrayBuffer()
+            ajax.body = requestObj;
+            ajax.generateRequest();
+
+            expect(server.requests[0]).to.be.ok;
+            // We give the browser the ArrayBuffer directly, without trying
+            // to encode it.
+            expect(server.requests[0].requestBody).to.be.equal(requestObj);
+          });
+        })
       });
 
       suite('when debouncing requests', function() {


### PR DESCRIPTION
Also greatly expanded the docs for `body`, as it seems to be a significant source of confusion for people.

Addresses #39