### PR TITLE
Convert all tests to use promises.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -399,14 +399,14 @@ element.
       this.fire('request', {
         request: request,
         options: requestOptions
-      });
+      }, {bubbles: false});
 
       return request;
     },
 
     _handleResponse: function(request) {
       this._setLastResponse(request.response);
-      this.fire('response', request);
+      this.fire('response', request, {bubbles: false});
     },
 
     _handleError: function(request, error) {
@@ -421,7 +421,7 @@ element.
       this.fire('error', {
         request: request,
         error: error
-      });
+      }, {bubbles: false});
     },
 
     _discardRequest: function(request) {

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
   </head>
   <body>

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>iron-ajax</title>
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
@@ -185,18 +185,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ajax.generateRequest()).to.be.instanceOf(IronRequest);
         });
 
-        test('reflects the loading state in the `loading` property', function(done) {
+        test('reflects the loading state in the `loading` property', function() {
           var request = ajax.generateRequest();
 
           expect(ajax.loading).to.be.equal(true);
 
           server.respond();
 
-          timePasses(1).then(function() {
+          return timePasses(1).then(function() {
             expect(ajax.loading).to.be.equal(false);
-            done();
-          }).catch(function(e) {
-            done(e);
           });
         });
       });
@@ -216,13 +213,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(requests).to.deep.eql(ajax.activeRequests);
         });
 
-        test('empties `activeRequests` when requests are completed', function(done) {
+        test('empties `activeRequests` when requests are completed', function() {
           server.respond();
-          timePasses(1).then(function() {
+          return timePasses(1).then(function() {
             expect(ajax.activeRequests.length).to.be.equal(0);
-            done();
-          }).catch(function(e) {
-            done(e);
           });
         });
       });
@@ -246,42 +240,48 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ajax = fixture('AutoGet');
         });
 
-        test('automatically generates new requests', function(done) {
-          ajax.addEventListener('request', function() {
-            done();
+        test('automatically generates new requests', function() {
+          return new Promise(function(resolve) {
+            ajax.addEventListener('request', function() {
+              resolve();
+            });
           });
         });
 
-        test('does not send requests if url is not a string', function(done) {
-          ajax.addEventListener('request', function() {
-            done(new Error('A request was generated but url is null!'));
+        test('does not send requests if url is not a string', function() {
+          return new Promise(function(resolve, reject) {
+            ajax.addEventListener('request', function() {
+              reject('A request was generated but url is null!');
+            });
+
+            ajax.url = null;
+            ajax.handleAs = 'text';
+
+            Polymer.Base.async(function() {
+              resolve();
+            }, 1);
           });
-
-          ajax.url = null;
-          ajax.handleAs = 'text';
-
-          Polymer.Base.async(function() {
-            done();
-          }, 1);
         });
 
-        test('deduplicates multiple changes to a single request', function(done) {
-          ajax.addEventListener('request', function() {
-            server.respond();
-          });
+        test('deduplicates multiple changes to a single request', function() {
+          return new Promise(function(resolve, reject) {
+            ajax.addEventListener('request', function() {
+              server.respond();
+            });
 
-          ajax.addEventListener('response', function() {
-            try {
-              expect(ajax.activeRequests.length).to.be.eql(1);
-              done();
-            } catch (e) {
-              done(e);
-            }
-          });
+            ajax.addEventListener('response', function() {
+              try {
+                expect(ajax.activeRequests.length).to.be.eql(1);
+                resolve()
+              } catch (e) {
+                reject(e);
+              }
+            });
 
-          ajax.handleas = 'text';
-          ajax.params = { foo: 'bar' };
-          ajax.headers = { 'X-Foo': 'Bar' };
+            ajax.handleas = 'text';
+            ajax.params = { foo: 'bar' };
+            ajax.headers = { 'X-Foo': 'Bar' };
+          });
         });
       });
 
@@ -291,16 +291,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           server.respond();
         });
 
-        test('is accessible as a readonly property', function(done) {
-          request.completes.then(function (request) {
+        test('is accessible as a readonly property', function() {
+          return request.completes.then(function (request) {
             expect(ajax.lastResponse).to.be.equal(request.response);
-            done();
-          }).catch(done);
+          });
         });
 
 
-        test('updates with each new response', function(done) {
-          request.completes.then(function(request) {
+        test('updates with each new response', function() {
+          return request.completes.then(function(request) {
 
             expect(request.response).to.be.an('object');
             expect(ajax.lastResponse).to.be.equal(request.response);
@@ -310,15 +309,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             server.respond();
 
             return request.completes;
-
           }).then(function(request) {
-
             expect(request.response).to.be.a('string');
             expect(ajax.lastResponse).to.be.equal(request.response);
-
-            done();
-
-          }).catch(done);
+          });
         });
       });
 
@@ -412,14 +406,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ajax = fixture('DebouncedGet');
         });
 
-        test('only requests a single resource', function(done) {
+        test('only requests a single resource', function() {
           ajax._requestOptionsChanged();
           expect(server.requests[0]).to.be.equal(undefined);
           ajax._requestOptionsChanged();
-          window.setTimeout(function() {
+          return timePasses(200).then(function() {
             expect(server.requests[0]).to.be.ok;
-            done();
-          }, 200);
+          });
         });
       });
 
@@ -431,16 +424,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ajax.addEventListener('response', responseHandler);
         });
 
-        test('calls the handler after every response', function(done) {
+        test('calls the handler after every response', function() {
           ajax.generateRequest();
           ajax.generateRequest();
 
           server.respond();
 
-          ajax.lastRequest.completes.then(function() {
+          return ajax.lastRequest.completes.then(function() {
             expect(responseHandler.callCount).to.be.equal(2);
-            done();
-          }).catch(done);
+          });
         });
       });
 
@@ -449,94 +441,77 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           server.restore();
         });
 
-        test('finds the JSON on any platform', function(done) {
+        test('finds the JSON on any platform', function() {
           ajax.url = '../bower.json';
           request = ajax.generateRequest();
-          request.completes.then(function() {
+          return request.completes.then(function() {
             expect(ajax.lastResponse).to.be.instanceOf(Object);
-            done();
-          }).catch(function(e) {
-            done(e);
           });
         });
       });
 
       suite('when handleAs parameter is `text`', function() {
 
-        test('response type is string', function (done) {
-
+        test('response type is string', function () {
           ajax.url = '/responds_to_get_with_json';
           ajax.handleAs = 'text';
 
           request = ajax.generateRequest();
-          request.completes.then(function () {
+          var promise = request.completes.then(function () {
             expect(typeof(ajax.lastResponse)).to.be.equal('string');
-            done();
-          }).catch(function (e) {
-            done(e);
           });
 
           server.respond();
 
+          return promise;
         });
 
       });
 
       suite('when a request fails', function() {
-        test('the error event has useful details', function(done) {
-
+        test('we give an error with useful details', function() {
           ajax.url = '/responds_to_get_with_text';
           ajax.handleAs = 'json';
-          ajax.generateRequest();
-
+          var eventFired = false;
           ajax.addEventListener('error', function(event) {
-            try {
-              expect(event.detail.request).to.be.okay;
-              expect(event.detail.error).to.be.okay;
-              done();
-            } catch (e) {
-              done(e);
-            }
+            // If we don't stop propagation the error event will bubble up
+            // to window, triggering window.onerror, which fails the
+            // test (on non-chrome browsers, because wct handles Chrome's
+            // onerror specially).
+            event.stopPropagation();
+            expect(event.detail.request).to.be.okay;
+            expect(event.detail.error).to.be.okay;
+            eventFired = true;
+          })
+          var promise = ajax.generateRequest().completes.then(function() {
+            throw new Error('Expected the request to fail!');
+          }, function(error) {
+            expect(error).to.be.instanceof(Error);
+            return timePasses(100);
+          }).then(function() {
+            expect(eventFired).to.be.eq(true);
           });
 
           server.respond();
+
+          return promise;
         });
       });
 
       suite('when handleAs parameter is `json`', function() {
 
-        test('response type is string', function (done) {
-
+        test('response type is string', function () {
           ajax.url = '/responds_to_get_with_json';
           ajax.handleAs = 'json';
 
           request = ajax.generateRequest();
-          request.completes.then(function () {
+          var promise = request.completes.then(function () {
             expect(typeof(ajax.lastResponse)).to.be.equal('object');
-            done();
-          }).catch(function (e) {
-            done(e);
           });
 
           server.respond();
 
-        });
-
-        test('fails when getting invalid json data', function (done) {
-
-          ajax.url = '/responds_to_get_with_text';
-          ajax.handleAs = 'json';
-
-          request = ajax.generateRequest();
-          request.completes.catch(function (e) {
-            expect(e).to.be.instanceOf(Error);
-            done();
-          }).catch(function (e) {
-            done(e);
-          });
-
-          server.respond();
-
+          return promise;
         });
 
       });

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>iron-ajax</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
@@ -493,15 +493,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ajax.handleAs = 'json';
           var eventFired = false;
           ajax.addEventListener('error', function(event) {
-            // If we don't stop propagation the error event will bubble up
-            // to window, triggering window.onerror, which fails the
-            // test (on non-chrome browsers, because wct handles Chrome's
-            // onerror specially).
-            event.stopPropagation();
             expect(event.detail.request).to.be.okay;
             expect(event.detail.error).to.be.okay;
             eventFired = true;
-          })
+          });
           var promise = ajax.generateRequest().completes.then(function() {
             throw new Error('Expected the request to fail!');
           }, function(error) {

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>iron-request</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
 

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -86,50 +86,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(request.xhr.async).to.be.eql(true);
         });
 
-        test('can be aborted', function (done) {
+        test('can be aborted', function () {
           request.send(successfulRequestOptions);
 
           request.abort();
 
           server.respond();
 
-          request.completes.then(function () {
-            done(new Error('Request did not abort appropriately!'));
+          return request.completes.then(function () {
+            throw new Error('Request did not abort appropriately!');
           }).catch(function (e) {
             expect(request.response).to.not.be.ok;
-            done();
           });
         });
 
-        test('default responseType is text', function (done) {
-
+        test('default responseType is text', function () {
           request.send(successfulRequestOptions);
           server.respond();
 
-          request.completes.then(function() {
+          return request.completes.then(function() {
             expect(request.response).to.be.an('string')
-            done();
-          }).catch(function(e) {
-            done(new Error('Response was not a Object'));
           });
-
         });
 
-        test('responseType can be configured via handleAs option', function (done) {
-
+        test('responseType can be configured via handleAs option', function () {
           var options = Object.create(successfulRequestOptions);
           options.handleAs = 'json';
 
           request.send(options);
           server.respond();
 
-          request.completes.then(function() {
+          return request.completes.then(function() {
             expect(request.response).to.be.an('object');
-            done();
-          }).catch(function(e) {
-            done(new Error('Response was not type Object'));
           });
-
         });
 
       });
@@ -176,7 +165,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           server.respond();
-          
+
           expect(request.status).to.be.equal(0);
           expect(request.statusText).to.be.equal('');
         });


### PR DESCRIPTION
Also improve our tests for errors. Ran into a difficult bug that
was the result of a combination of window.onerror firing because
iron-ajax's error event had bubbled up, and the fact that we were
using webcomponents.js, which wrapped the CustomEvent in some
cases, which interfered with event.stopPropagation() on Firefox.