### PR TITLE
Added response parsing on error

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -187,13 +187,13 @@ iron-request can be used to perform XMLHttpRequests.
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4 && !this.aborted) {
           this._updateStatus();
+          this._setResponse(this.parseResponse());
 
           if (!this.succeeded) {
             this.rejectCompletes(new Error('The request failed with status code: ' + this.xhr.status));
             return;
           }
 
-          this._setResponse(this.parseResponse());
           this.resolveCompletes(this);
         }
       }.bind(this));
@@ -369,4 +369,3 @@ iron-request can be used to perform XMLHttpRequests.
     }
   });
 </script>
-


### PR DESCRIPTION
Hi guys!
I was playing around with iron-ajax and having trouble reading the response when the request is not successful. 
I don't know if it was done on purpose but the iron-request was not parsing the response when an error occurs while it might be really useful (same status but different errors for instance).

If you want to change it, I fixed it, if not, feel free to decline this pull request!