### PR TITLE
Observe sub-properties of params (fixes #96)

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -275,7 +275,7 @@ element.
     },
 
     observers: [
-      '_requestOptionsChanged(url, method, params, headers,' +
+      '_requestOptionsChanged(url, method, params.*, headers,' +
         'contentType, body, sync, handleAs, withCredentials, auto)'
     ],
 

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -296,6 +296,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ajax.params = { foo: 'bar' };
           ajax.headers = { 'X-Foo': 'Bar' };
         });
+        
+        test('automatically generates new request when a sub-property of params is changed', function(done) {
+          ajax.addEventListener('request', function() {
+            server.respond();
+          });
+          
+          ajax.params = { foo: 'bar' };
+          ajax.addEventListener('response', function() {
+            ajax.addEventListener('request', function() {
+              done();
+            });
+            
+            ajax.set('params.foo', 'xyz');
+          });
+        });
       });
 
       suite('the last response', function() {


### PR DESCRIPTION
This changes the observers of `iron-ajax` so that also subproperties of `params` are observed for changes. A test was added to check that it will generate a new request when `auto` is enabled and a subproperty is changed using the `set` API.