### PR TITLE
No longer setting responseType on synchronous calls

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -241,7 +241,9 @@ iron-request can be used to perform XMLHttpRequests.
 
       // In IE, `xhr.responseType` is an empty string when the response
       // returns. Hence, caching it as `xhr._responseType`.
-      xhr.responseType = xhr._responseType = (options.handleAs || 'text');
+      if (options.async) {
+        xhr.responseType = xhr._responseType = (options.handleAs || 'text');
+      }
       xhr.withCredentials = !!options.withCredentials;
 
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -241,7 +241,7 @@ iron-request can be used to perform XMLHttpRequests.
 
       // In IE, `xhr.responseType` is an empty string when the response
       // returns. Hence, caching it as `xhr._responseType`.
-      if (options.async) {
+      if (options.async !== false) {
         xhr.responseType = xhr._responseType = (options.handleAs || 'text');
       }
       xhr.withCredentials = !!options.withCredentials;

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -109,16 +109,49 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('default responseType of text is not applied, when async is false', function (done) {
+          var options = Object.create(successfulRequestOptions);
+          options.async = false;
+
+          request.send(options);
+          server.respond();
+
+          request.completes.then(function() {
+            expect(request.xhr.responseType).to.be.empty;
+            done();
+          }).catch(function(e) {
+            done(new Error('ResponseType was not empty'));
+          });
+
+        });
+
         test('responseType can be configured via handleAs option', function () {
           var options = Object.create(successfulRequestOptions);
           options.handleAs = 'json';
-
+          
           request.send(options);
           server.respond();
 
           return request.completes.then(function() {
             expect(request.response).to.be.an('object');
           });
+        });
+
+        test('responseType cannot be configured via handleAs option, when async is false', function (done) {
+          var options = Object.create(successfulRequestOptions);
+          options.handleAs = 'json';
+          options.async = false;
+
+          request.send(options);
+          server.respond();
+
+          request.completes.then(function() {
+            expect(request.response).to.be.an('string');
+            done();
+          }).catch(function(e) {
+            done(new Error('Response was not a String'));
+          });
+
         });
 
       });

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -109,20 +109,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('default responseType of text is not applied, when async is false', function (done) {
+        test('default responseType of text is not applied, when async is false', function () {
           var options = Object.create(successfulRequestOptions);
           options.async = false;
 
           request.send(options);
           server.respond();
 
-          request.completes.then(function() {
+          return request.completes.then(function() {
             expect(request.xhr.responseType).to.be.empty;
-            done();
-          }).catch(function(e) {
-            done(new Error('ResponseType was not empty'));
           });
-
         });
 
         test('responseType can be configured via handleAs option', function () {
@@ -137,7 +133,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('responseType cannot be configured via handleAs option, when async is false', function (done) {
+        test('responseType cannot be configured via handleAs option, when async is false', function () {
           var options = Object.create(successfulRequestOptions);
           options.handleAs = 'json';
           options.async = false;
@@ -145,13 +141,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           request.send(options);
           server.respond();
 
-          request.completes.then(function() {
-            expect(request.response).to.be.an('string');
-            done();
-          }).catch(function(e) {
-            done(new Error('Response was not a String'));
+          return request.completes.then(function() {
+            expect(request.response).to.be.a('string');
           });
-
         });
 
       });


### PR DESCRIPTION
The request errors on synchronous calls when responseType is set.