### PR TITLE
Move from readystatechanged to loadend.

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -186,20 +186,6 @@ iron-request can be used to perform XMLHttpRequests.
         return null;
       }
 
-      xhr.addEventListener('readystatechange', function () {
-        if (xhr.readyState === 4 && !this.aborted) {
-          this._updateStatus();
-
-          if (!this.succeeded) {
-            this.rejectCompletes(new Error('The request failed with status code: ' + this.xhr.status));
-            return;
-          }
-
-          this._setResponse(this.parseResponse());
-          this.resolveCompletes(this);
-        }
-      }.bind(this));
-
       xhr.addEventListener('progress', function (progress) {
         this._setProgress({
           lengthComputable: progress.lengthComputable,
@@ -218,6 +204,20 @@ iron-request can be used to perform XMLHttpRequests.
         this.rejectCompletes(new Error('Request aborted.'));
       }.bind(this));
 
+      // Called after all of the above.
+      xhr.addEventListener('loadend', function () {
+        this._updateStatus();
+
+        if (!this.succeeded) {
+          this.rejectCompletes(new Error('The request failed with status code: ' + this.xhr.status));
+          return;
+        }
+
+        this._setResponse(this.parseResponse());
+        this.resolveCompletes(this);
+      }.bind(this));
+
+      this.url = options.url;
       xhr.open(
         options.method || 'GET',
         options.url,
@@ -264,29 +264,25 @@ iron-request can be used to perform XMLHttpRequests.
      */
     parseResponse: function () {
       var xhr = this.xhr;
-      var responseType = this.xhr.responseType ||
-        this.xhr._responseType;
-      // If we don't have a natural `xhr.responseType`, we prefer parsing
-      // `xhr.responseText` over returning `xhr.response`..
+      var responseType = xhr.responseType || xhr._responseType;
       var preferResponseText = !this.xhr.responseType;
 
       try {
         switch (responseType) {
           case 'json':
-            // If xhr.response is undefined, responseType `json` may
-            // not be supported.
+            // If the xhr object doesn't have a natural `xhr.responseType`,
+            // we can assume that the browser hasn't parsed the response for us,
+            // and so parsing is our responsibility. Likewise if response is
+            // undefined, as there's no way to encode undefined in JSON.
             if (preferResponseText || xhr.response === undefined) {
-              // If accessing `xhr.responseText` throws, responseType `json`
-              // is supported and the result is rightly `undefined`.
+              // Try to emulate the JSON section of the response body section of
+              // the spec: https://xhr.spec.whatwg.org/#response-body
+              // That is to say, we try to parse as JSON, but if anything goes
+              // wrong return null.
               try {
-                /** @suppress {suspiciousCode} */ xhr.responseText;
-              } catch (e) {
-                return xhr.response;
-              }
-
-              // Otherwise, attempt to parse `xhr.responseText` as JSON.
-              if (xhr.responseText) {
-                return JSON.parse(xhr.responseText);
+                return JSON.parse(xhr.responseText);;
+              } catch (_) {
+                return null;
               }
             }
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -138,18 +138,34 @@ iron-request can be used to perform XMLHttpRequests.
         notify: true,
         readOnly: true,
         value: false,
+      },
+
+      /**
+       * Errored will be true if the browser fired an error event from the
+       * XHR object (mainly network errors).
+       */
+      errored: {
+        type: Boolean,
+        notify: true,
+        readOnly: true,
+        value: false
       }
     },
 
     /**
-     * Succeeded is true if the request succeeded. The request succeeded if the
-     * status code is greater-than-or-equal-to 200, and less-than 300. Also,
-     * the status code 0 is accepted as a success even though the outcome may
-     * be ambiguous.
+     * Succeeded is true if the request succeeded. The request succeeded if it
+     * loaded without error, wasn't aborted, and the status code is ≥ 200, and
+     * < 300, or if the status code is 0.
+     *
+     * The status code 0 is accepted as a success because some schemes - e.g.
+     * file:// - don't provide status codes.
      *
      * @return {boolean}
      */
     get succeeded() {
+      if (this.errored || this.aborted) {
+        return false;
+      }
       var status = this.xhr.status || 0;
 
       // Note: if we are using the file:// protocol, the status code will be 0
@@ -195,6 +211,7 @@ iron-request can be used to perform XMLHttpRequests.
       }.bind(this))
 
       xhr.addEventListener('error', function (error) {
+        this._setErrored(true);
         this._updateStatus();
         this.rejectCompletes(error);
       }.bind(this));

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -602,10 +602,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(event.detail.error).to.be.okay;
             eventFired = true;
           });
-          var promise = ajax.generateRequest().completes.then(function() {
+          var request = ajax.generateRequest();
+          var promise = request.completes.then(function() {
             throw new Error('Expected the request to fail!');
           }, function(error) {
             expect(error).to.be.instanceof(Error);
+            expect(request.succeeded).to.be.eq(false);
             return timePasses(100);
           }).then(function() {
             expect(eventFired).to.be.eq(true);
@@ -626,10 +628,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(event.detail.error).to.be.okay;
             eventFired = true;
           });
-          var promise = ajax.generateRequest().completes.then(function(xhr) {
-            console.log(xhr);
+          var request = ajax.generateRequest();
+          var promise = request.completes.then(function() {
             throw new Error('Expected the request to fail!');
           }, function(error) {
+            expect(request.succeeded).to.be.eq(false);
             expect(error).to.not.be.eq(null);
             return timePasses(100);
           }).then(function() {

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -127,6 +127,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ]
         );
 
+        server.respondWith(
+          'GET',
+          '/responds_to_get_with_502_error_json',
+          [
+            502,
+            responseHeaders.json,
+            '{"message": "an error has occurred"}'
+          ]
+        );
+
         ajax = fixture('TrivialGet');
       });
 
@@ -584,7 +594,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('when a request fails', function() {
         test('we give an error with useful details', function() {
-          ajax.url = '/responds_to_get_with_text';
+          ajax.url = '/responds_to_get_with_502_error_json';
           ajax.handleAs = 'json';
           var eventFired = false;
           ajax.addEventListener('error', function(event) {
@@ -599,6 +609,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             return timePasses(100);
           }).then(function() {
             expect(eventFired).to.be.eq(true);
+            expect(ajax.lastError).to.not.be.eq(null);
+          });
+
+          server.respond();
+
+          return promise;
+        });
+
+        test('we give a useful error even when the domain doesn\'t resolve', function() {
+          ajax.url = 'http://nonexistant.example.com/';
+          server.restore();
+          var eventFired = false;
+          ajax.addEventListener('error', function(event) {
+            expect(event.detail.request).to.be.okay;
+            expect(event.detail.error).to.be.okay;
+            eventFired = true;
+          });
+          var promise = ajax.generateRequest().completes.then(function(xhr) {
+            console.log(xhr);
+            throw new Error('Expected the request to fail!');
+          }, function(error) {
+            expect(error).to.not.be.eq(null);
+            return timePasses(100);
+          }).then(function() {
+            expect(eventFired).to.be.eq(true);
+            expect(ajax.lastError).to.not.be.eq(null);
           });
 
           server.respond();


### PR DESCRIPTION
readystatechanged is fired *before* any other end-of-request events
are called. This is sub-optimal because we have to guess whether the
request is successful or it failed based on not a lot of information.

If we instead put this guessing code in loadend which fires *after*,
and use the 'error' event to catch network errors, we can catch more
kinds of error that aren't reflected in properties on the XHR object..

This PR also changes our manual JSON parse behavior to return null
if we can't parse the JSON. This is so that our json XHR polyfill 
behaves more like the native behavior. i.e. we should only parse the
JSON if the browser didn't do it for us, and if the browser does it for
us, it's spec'd to return null if there's a parse error.