### PR TITLE
No automatic requests without a url.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -69,8 +69,7 @@ element.
        * The URL target of the request.
        */
       url: {
-        type: String,
-        value: ''
+        type: String
       },
 
       /**
@@ -381,7 +380,7 @@ element.
      */
     toRequestOptions: function() {
       return {
-        url: this.requestUrl,
+        url: this.requestUrl || '',
         method: this.method,
         headers: this.requestHeaders,
         body: this.body,
@@ -462,7 +461,7 @@ element.
 
     _requestOptionsChanged: function() {
       this.debounce('generate-request', function() {
-        if (!this.url && this.url !== '') {
+        if (this.url == null) {
           return;
         }
 

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -55,6 +55,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                  debounce-duration="150"></iron-ajax>
     </template>
   </test-fixture>
+  <test-fixture id='BlankUrl'>
+    <template>
+      <iron-ajax auto handle-as='text'></iron-ajax>
+    </template>
+  </test-fixture>
   <!-- note(rictic):
        This makes us dependent on a third-party server, but we need to be able
        to check what headers the browser actually sends on the wire.
@@ -194,6 +199,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var options = ajax.toRequestOptions();
 
           expect(Object.keys(options.headers).length).to.be.equal(0);
+        });
+      });
+
+      suite('when url isn\'t set yet', function() {
+        test('we don\'t fire any automatic requests', function() {
+          expect(server.requests.length).to.be.equal(0);
+          ajax = fixture('BlankUrl');
+
+          return timePasses(1).then(function() {
+            // We don't make any requests.
+            expect(server.requests.length).to.be.equal(0);
+
+            // Explicitly asking for the request to fire works.
+            ajax.generateRequest();
+            expect(server.requests.length).to.be.equal(1);
+            server.requests = [];
+
+            // Explicitly setting url to '' works too.
+            ajax = fixture('BlankUrl');
+            ajax.url = '';
+            return timePasses(1);
+          }).then(function() {
+            expect(server.requests.length).to.be.equal(1);
+          });
         });
       });
 


### PR DESCRIPTION
We've got this bug where we send unintended requests when the URL hasn't yet been set: https://github.com/PolymerElements/iron-ajax/issues/55

The fix that people have been proposing is that we not fire requests when the URL is the empty string. The tricky thing there is that an empty string URL is totally valid, it refers to the current URL. This isn't just a theoritical use either, it's not uncommon for servers to return different results for a URL based on method, params, accept headers, etc.

This commit tries to thread the needle of back-compat and user intent. The URL now defaults to `null`, and we won't perform any automatic requests while the url is `null`. If you explictly set the url to `''` then requests will fire, and if you call generateRequest with a `null` url we'll treat it as `''`.

This will hopefully solve the unintended request problem while also giving users control of when requests will and won't be fired (by setting the url to null), while having minimal impact on users that are happy with the current behavior.

Fixes #55