### PR TITLE
Move header lowercasing into iron-request.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -241,7 +241,7 @@ element.
        *
        * The type of the response is determined by the value of `handleAs` at
        * the time that the request was generated.
-       * 
+       *
        * @type {Object}
        */
       lastResponse: {
@@ -252,7 +252,7 @@ element.
 
       /**
        * lastRequest's error, if any.
-       * 
+       *
        * @type {Object}
        */
       lastError: {
@@ -362,9 +362,7 @@ element.
 
       if (this.headers instanceof Object) {
         for (header in this.headers) {
-          // Normalize headers in lower case to make it easier for iron-request
-          // to reason about them.
-          headers[header.toLowerCase()] = this.headers[header].toString();
+          headers[header] = this.headers[header].toString();
         }
       }
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -183,7 +183,7 @@ iron-request can be used to perform XMLHttpRequests.
      *     async By default, all requests are sent asynchronously. To send synchronous requests,
      *         set to true.
      *     body The content for the request body for POST method.
-     *     headers HTTP request headers. All keys must be lower case.
+     *     headers HTTP request headers.
      *     handleAs The response type. Default is 'text'.
      *     withCredentials Whether or not to send credentials on the request. Default is false.
      *   timeout: (Number|undefined)
@@ -221,6 +221,7 @@ iron-request can be used to perform XMLHttpRequests.
         this.rejectCompletes(new Error('Request aborted.'));
       }.bind(this));
 
+
       // Called after all of the above.
       xhr.addEventListener('loadend', function () {
         this._updateStatus();
@@ -248,7 +249,13 @@ iron-request can be used to perform XMLHttpRequests.
         'xml': 'application/xml',
         'arraybuffer': 'application/octet-stream'
       }[options.handleAs];
-      var headers = options.headers || {};
+      var headers = options.headers || Object.create(null);
+      var newHeaders = Object.create(null);
+      for (var key in headers) {
+        newHeaders[key.toLowerCase()] = headers[key];
+      }
+      headers = newHeaders;
+
       if (acceptType && !headers['accept']) {
         headers['accept'] = acceptType;
       }

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -152,6 +152,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('headers are sent up', function() {
+          var options = Object.create(successfulRequestOptions);
+          options.headers = {
+            'foo': 'bar',
+            'accept': 'this should override the default'
+          };
+          request.send(options);
+          expect(server.requests.length).to.be.equal(1);
+          var fakeXhr = server.requests[0]
+          expect(fakeXhr.requestHeaders['foo']).to.be.equal(
+              'bar');
+          expect(fakeXhr.requestHeaders['accept']).to.be.equal(
+              'this should override the default');
+        });
+
+        test('headers are deduped by lowercasing', function() {
+          var options = Object.create(successfulRequestOptions);
+          options.headers = {
+            'foo': 'bar',
+            'Foo': 'bar',
+            'fOo': 'bar',
+            'Accept': 'this should also override the default'
+          };
+          request.send(options);
+          expect(server.requests.length).to.be.equal(1);
+          var fakeXhr = server.requests[0]
+          expect(Object.keys(fakeXhr.requestHeaders).length).to.be.equal(2);
+          expect(fakeXhr.requestHeaders['foo']).to.be.equal(
+              'bar');
+          expect(fakeXhr.requestHeaders['accept']).to.be.equal(
+              'this should also override the default');
+        });
       });
 
       suite('special cases', function() {


### PR DESCRIPTION
This better preserves the previous behavior while still fixing the bug that
we depended upon the capitalization of headers in iron-request.