### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,11 +25,10 @@
   },
   "devDependencies": {
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-    "iron-flex-layout": "polymerelements/iron-flex-layout#^1.0.0",
     "iron-image": "polymerelements/iron-image#^1.0.0",
     "paper-styles": "polymerelements/paper-styles#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,36 +15,38 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../iron-ajax.html">
   <link rel="import" href="../../iron-image/iron-image.html">
-  <link rel="import" href="../../paper-styles/classes/typography.html">
-  <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
-  <link rel="stylesheet" href="../../paper-styles/demo.css">
+  <link rel="import" href="../../paper-styles/demo-pages.html">
   <style>
     iron-image {
       background-color: lightgray;
       margin: 1em;
     }
+    .horizontal-section {
+      max-width: 300px;
+      margin-bottom: 24px;
+    }
   </style>
 </head>
-<body>
+<body unresolved>
+  <h1>Video Feed</h1>
+  <div class="horizontal-section-container">
+    <template is="dom-bind" id="app">
+      <iron-ajax auto
+          url="https://www.googleapis.com/youtube/v3/search"
+          params='{"part":"snippet", "q":"polymer", "key": "AIzaSyAuecFZ9xJXbGDkQYWBmYrtzOGJD-iDIgI", "type": "video"}'
+          handle-as="json"
+          last-response="{{ajaxResponse}}"></iron-ajax>
 
-  <template is="dom-bind" id="app">
-    <iron-ajax auto
-        url="https://www.googleapis.com/youtube/v3/search"
-        params='{"part":"snippet", "q":"polymer", "key": "AIzaSyAuecFZ9xJXbGDkQYWBmYrtzOGJD-iDIgI", "type": "video"}'
-        handle-as="json"
-        last-response="{{ajaxResponse}}"></iron-ajax>
+        <template is="dom-repeat" items="[[ajaxResponse.items]]">
+          <div class="horizontal-section">
+            <h2><a href="[[url(item.id.videoId)]]" target="_blank">[[item.snippet.title]]</a></h2>
+            <iron-image src="[[item.snippet.thumbnails.high.url]]" width="256" height="256" sizing="cover" preload fade></iron-image>
+            <p>[[item.snippet.description]]</p>
+          </div>
+        </template>
 
-    <h1>Video Feed</h1>
-    <section class="flex layout horizontal wrap">
-      <template is="dom-repeat" items="[[ajaxResponse.items]]">
-        <div>
-          <h2><a href="[[url(item.id.videoId)]]" target="_blank">[[item.snippet.title]]</a></h2>
-          <iron-image src="[[item.snippet.thumbnails.high.url]]" width="256" height="256" sizing="cover" preload fade></iron-image>
-          <p>[[item.snippet.description]]</p>
-        </div>
-      </template>
-    </section>
-  </template>
+    </template>
+  </div>
 
   <script>
     var app = document.querySelector('#app');

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -13,11 +13,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-ajax.html">
 </head>
 <body>

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -13,10 +13,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-request.html">
 </head>
 <body>


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way

Also, because this was in the way, I prettified the demo slightly for free:
<img width="1359" alt="screen shot 2015-11-17 at 3 29 46 pm" src="https://cloud.githubusercontent.com/assets/1369170/11228250/3b637a5a-8d40-11e5-97e1-f78d61bacfca.png">

/cc @rictic 