### PR TITLE
added 'iron-request' to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,10 @@
     "polymer",
     "ajax"
   ],
-  "main": "iron-ajax.html",
+  "main": [
+    "iron-ajax.html",
+    "iron-request.html"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/PolymerElements/iron-ajax.git"


### PR DESCRIPTION
Fixes #163

The component `iron-request` was added to `main` since `iron-ajax` requires it.