### PR TITLE
test loading-changed event

### DIFF
--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -277,6 +277,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(ajax.loading).to.be.equal(false);
           });
         });
+
+        test('the loading-changed event gets fired twice', function() {
+
+          var count = 0;
+          ajax.addEventListener('loading-changed', function() {
+            count++;
+          });
+
+          var request = ajax.generateRequest();
+
+          server.respond();
+
+          return request.completes.then(function() {
+            return timePasses(1);
+          }).then(function() {
+            expect(count).to.be.equal(2);
+          });
+
+        });
       });
 
       suite('when there are multiple requests', function() {


### PR DESCRIPTION
There was a question on the mailing list (later to issue #115) this additional unit test can answer.

Ensures the `loading-changed` event is fired properly.

---
As @cdata wished, this PR was re-created from #118 after the CI service was updated.