### PR TITLE
Fixing rare 'indexOf' of undefined error

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -419,6 +419,9 @@ element.
      * @return {!IronRequestElement}
      */
     generateRequest: function() {
+      if (!this.url) {
+          return undefined;
+      }
       var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
       var requestOptions = this.toRequestOptions();
 


### PR DESCRIPTION
When a user sets parameters but not a url, iron-ajax will crash (Cannot read property 'indexOf' of undefined). This happens in the get requestUrl() function.

One could fix it there by adding an if() statement in the requestUrl getter, but then we fire unwanted requests again (issue #55).
Therefore I would propose adding an if (!this.url) statement to generateRequest(). It will once and for all squash #55.