### PR TITLE
Making the iron-ajax bubbling behavior configurable.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -300,7 +300,9 @@ element.
       },
 
       /**
-       * Whether the request, response, and error events should bubble to document.
+       * By default, these events do not bubble largely because the `error` event has special
+       * meaning in the window object. Setting this attribute will cause iron-ajax's request,
+       * response, and error events to bubble to the window object.
        */
       bubbles: {
         type: Boolean,

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -299,6 +299,14 @@ element.
         value: ''
       },
 
+      /**
+       * Whether the request, response, and error events should bubble to document.
+       */
+      bubbles: {
+        type: Boolean,
+        value: false
+      },
+
       _boundHandleResponse: {
         type: Function,
         value: function() {
@@ -440,7 +448,7 @@ element.
       this.fire('request', {
         request: request,
         options: requestOptions
-      }, {bubbles: false});
+      }, {bubbles: this.bubbles});
 
       return request;
     },
@@ -451,7 +459,7 @@ element.
         this._setLastError(null);
         this._setLoading(false);
       }
-      this.fire('response', request, {bubbles: false});
+      this.fire('response', request, {bubbles: this.bubbles});
     },
 
     _handleError: function(request, error) {
@@ -470,7 +478,7 @@ element.
       this.fire('error', {
         request: request,
         error: error
-      }, {bubbles: false});
+      }, {bubbles: this.bubbles});
     },
 
     _discardRequest: function(request) {

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -74,6 +74,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-ajax url="http://httpbin.org/delay/1"></iron-ajax>
     </template>
   </test-fixture>
+  <test-fixture id="Bubbles">
+    <template>
+      <iron-ajax url="http://httpbin.org/get" bubbles></iron-ajax>
+      <iron-ajax url="/responds_to_get_with_502_error_json" bubbles></iron-ajax>
+    </template>
+  </test-fixture>
   <script>
     'use strict';
     suite('<iron-ajax>', function () {
@@ -815,6 +821,39 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(ajax.lastResponse).to.be.equal(null);
             expect(ajax.lastError).to.not.be.equal(null);
           });
+        });
+      });
+
+      suite('when using the bubbles attribute', function () {
+        setup(function() {
+          server.restore();
+        });
+        test('the request and response events should bubble to window', function (done) {
+          server.restore();
+          var total = 0;
+          function incrementTotal(){
+            total++;
+            if(total === 1) done();
+          }
+          window.addEventListener('request', incrementTotal);
+          document.addEventListener('response', incrementTotal);
+          var ajax = fixture('Bubbles')[0];
+          ajax.generateRequest();
+          server.respond();
+        });
+
+        test('the request and error events should bubble to window', function (done) {
+          server.restore();
+          var total = 0;
+          function incrementTotal(){
+            total++;
+            if(total === 2) done();
+          }
+          window.addEventListener('request', incrementTotal);
+          window.addEventListener('error', incrementTotal);
+          var ajax = fixture('Bubbles')[1];
+          ajax.generateRequest();
+          server.respond();
         });
       });
 

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -58,20 +58,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-ajax auto handle-as='text'></iron-ajax>
     </template>
   </test-fixture>
-  <!-- note(rictic):
-       This makes us dependent on a third-party server, but we need to be able
-       to check what headers the browser actually sends on the wire.
-       If necessary we can spin up our own httpbin server, as the code is open
-       source.
-    -->
   <test-fixture id="RealPost">
     <template>
-      <iron-ajax method="POST" url="http://httpbin.org/post"></iron-ajax>
+      <iron-ajax method="POST" url="/httpbin/post"></iron-ajax>
     </template>
   </test-fixture>
   <test-fixture id="Delay">
     <template>
-      <iron-ajax url="http://httpbin.org/delay/1"></iron-ajax>
+      <iron-ajax url="/httpbin/delay/1"></iron-ajax>
     </template>
   </test-fixture>
   <test-fixture id="Bubbles">

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -833,7 +833,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var total = 0;
           function incrementTotal(){
             total++;
-            if(total === 2) done();
+            if (total === 2){
+              done();
+            }
           }
           window.addEventListener('request', incrementTotal);
           document.addEventListener('response', incrementTotal);
@@ -847,7 +849,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var total = 0;
           function incrementTotal(){
             total++;
-            if(total === 2) done();
+            if (total === 2){
+              done();
+            }
           }
           window.addEventListener('request', incrementTotal);
           window.addEventListener('error', incrementTotal);

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -838,7 +838,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             }
           }
           window.addEventListener('request', incrementTotal);
-          document.addEventListener('response', incrementTotal);
+          window.addEventListener('response', incrementTotal);
           var ajax = fixture('Bubbles')[0];
           ajax.generateRequest();
           server.respond();

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -70,7 +70,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
   <test-fixture id="Bubbles">
     <template>
-      <iron-ajax url="http://httpbin.org/get" bubbles></iron-ajax>
+      <iron-ajax url="/httpbin/post" method="POST" bubbles></iron-ajax>
       <iron-ajax url="/responds_to_get_with_502_error_json" bubbles></iron-ajax>
     </template>
   </test-fixture>

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -833,7 +833,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var total = 0;
           function incrementTotal(){
             total++;
-            if(total === 1) done();
+            if(total === 2) done();
           }
           window.addEventListener('request', incrementTotal);
           document.addEventListener('response', incrementTotal);


### PR DESCRIPTION
I would like the ability to have:

* Flux-like ajax response handling and
* App-wide iron-ajax interceptors

To facilitate these, this PR proposes making iron-ajax event bubbling configurable, though default off. I'm willing to do more coding, but wanted to submit this PR to see if this is something the team is willing to consider before investing more time.