### PR TITLE
Addressing scoped event naming with backwards compatibility

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -46,18 +46,21 @@ element.
      * Fired when a request is sent.
      *
      * @event request
+     * @event iron-ajax-request (only when this.bubbles is true)
      */
 
     /**
      * Fired when a response is received.
      *
      * @event response
+     * @event iron-ajax-response (only when this.bubbles is true)
      */
 
     /**
      * Fired when an error is received.
      *
      * @event error
+     * @event iron-ajax-error (only when this.bubbles is true)
      */
 
     hostAttributes: {
@@ -302,7 +305,8 @@ element.
       /**
        * By default, these events do not bubble largely because the `error` event has special
        * meaning in the window object. Setting this attribute will cause iron-ajax's request,
-       * response, and error events to bubble to the window object.
+       * response, and error events to bubble to the window object. It will also cause
+       * iron-ajax to emit duplicate events prefixed with "iron-ajax-".
        */
       bubbles: {
         type: Boolean,
@@ -452,6 +456,13 @@ element.
         options: requestOptions
       }, {bubbles: this.bubbles});
 
+      if(this.bubbles){
+        this.fire('request', {
+          request: request,
+          options: requestOptions
+        }, {bubbles: true});
+      }
+
       return request;
     },
 
@@ -462,6 +473,9 @@ element.
         this._setLoading(false);
       }
       this.fire('response', request, {bubbles: this.bubbles});
+      if(this.bubbles){
+        this.fire('iron-ajax-response', request, {bubbles: true});
+      }
     },
 
     _handleError: function(request, error) {
@@ -477,6 +491,15 @@ element.
         this._setLastResponse(null);
         this._setLoading(false);
       }
+
+      // Tests fail if this goes after the normal this.fire('error', ...)
+      if(this.bubbles){
+        this.fire('iron-ajax-error', {
+          request: request,
+          error: error
+        }, {bubbles: true});
+      }
+
       this.fire('error', {
         request: request,
         error: error

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -457,7 +457,7 @@ element.
       }, {bubbles: this.bubbles});
 
       if(this.bubbles){
-        this.fire('request', {
+        this.fire('iron-ajax-request', {
           request: request,
           options: requestOptions
         }, {bubbles: true});

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -46,21 +46,21 @@ element.
      * Fired when a request is sent.
      *
      * @event request
-     * @event iron-ajax-request (only when this.bubbles is true)
+     * @event iron-ajax-request
      */
 
     /**
      * Fired when a response is received.
      *
      * @event response
-     * @event iron-ajax-response (only when this.bubbles is true)
+     * @event iron-ajax-response
      */
 
     /**
      * Fired when an error is received.
      *
      * @event error
-     * @event iron-ajax-error (only when this.bubbles is true)
+     * @event iron-ajax-error
      */
 
     hostAttributes: {
@@ -303,10 +303,12 @@ element.
       },
 
       /**
-       * By default, these events do not bubble largely because the `error` event has special
-       * meaning in the window object. Setting this attribute will cause iron-ajax's request,
-       * response, and error events to bubble to the window object. It will also cause
-       * iron-ajax to emit duplicate events prefixed with "iron-ajax-".
+       * By default, these events do not bubble. Setting this attribute will cause iron-ajax's
+       * request, and response events as well as its iron-ajax-request, -response,  and -error
+       * events to bubble to the window object. The vanilla error event never bubbles even if
+       * this.bubbles is true because the shadow dom spec does not allow certain events,
+       * including events named error, to leak, outside of shadow trees.
+       * https://www.w3.org/TR/2015/WD-shadow-dom-20151215/#events-that-are-not-leaked-into-ancestor-trees
        */
       bubbles: {
         type: Boolean,
@@ -456,12 +458,10 @@ element.
         options: requestOptions
       }, {bubbles: this.bubbles});
 
-      if(this.bubbles){
-        this.fire('iron-ajax-request', {
-          request: request,
-          options: requestOptions
-        }, {bubbles: true});
-      }
+      this.fire('iron-ajax-request', {
+        request: request,
+        options: requestOptions
+      }, {bubbles: this.bubbles});
 
       return request;
     },
@@ -473,9 +473,7 @@ element.
         this._setLoading(false);
       }
       this.fire('response', request, {bubbles: this.bubbles});
-      if(this.bubbles){
-        this.fire('iron-ajax-response', request, {bubbles: true});
-      }
+      this.fire('iron-ajax-response', request, {bubbles: this.bubbles});
     },
 
     _handleError: function(request, error) {
@@ -493,12 +491,10 @@ element.
       }
 
       // Tests fail if this goes after the normal this.fire('error', ...)
-      if(this.bubbles){
-        this.fire('iron-ajax-error', {
-          request: request,
-          error: error
-        }, {bubbles: true});
-      }
+      this.fire('iron-ajax-error', {
+        request: request,
+        error: error
+      }, {bubbles: this.bubbles});
 
       this.fire('error', {
         request: request,

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -303,11 +303,13 @@ element.
       },
 
       /**
-       * By default, these events do not bubble. Setting this attribute will cause iron-ajax's
-       * request, and response events as well as its iron-ajax-request, -response,  and -error
-       * events to bubble to the window object. The vanilla error event never bubbles even if
-       * this.bubbles is true because the shadow dom spec does not allow certain events,
-       * including events named error, to leak outside of shadow trees.
+       * By default, iron-ajax's events do not bubble. Setting this attribute will cause its
+       * request and response events as well as its iron-ajax-request, -response,  and -error
+       * events to bubble to the window object. The vanilla error event never bubbles when
+       * using shadow dom even if this.bubbles is true because a scoped flag is not passed with
+       * it (first link) and because the shadow dom spec did not used to allow certain events,
+       * including events named error, to leak outside of shadow trees (second link).
+       * https://www.w3.org/TR/shadow-dom/#scoped-flag
        * https://www.w3.org/TR/2015/WD-shadow-dom-20151215/#events-that-are-not-leaked-into-ancestor-trees
        */
       bubbles: {

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -307,7 +307,7 @@ element.
        * request, and response events as well as its iron-ajax-request, -response,  and -error
        * events to bubble to the window object. The vanilla error event never bubbles even if
        * this.bubbles is true because the shadow dom spec does not allow certain events,
-       * including events named error, to leak, outside of shadow trees.
+       * including events named error, to leak outside of shadow trees.
        * https://www.w3.org/TR/2015/WD-shadow-dom-20151215/#events-that-are-not-leaked-into-ancestor-trees
        */
       bubbles: {

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -827,12 +827,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var total = 0;
           function incrementTotal(){
             total++;
-            if (total === 2){
+            if (total === 4){
               done();
             }
           }
           window.addEventListener('request', incrementTotal);
+          window.addEventListener('iron-ajax-request', incrementTotal);
           window.addEventListener('response', incrementTotal);
+          window.addEventListener('iron-ajax-response', incrementTotal);
           var ajax = fixture('Bubbles')[0];
           ajax.generateRequest();
           server.respond();
@@ -843,12 +845,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var total = 0;
           function incrementTotal(){
             total++;
-            if (total === 2){
+            if (total === 4){
               done();
             }
           }
           window.addEventListener('request', incrementTotal);
+          window.addEventListener('iron-ajax-request', incrementTotal);
           window.addEventListener('error', incrementTotal);
+          window.addEventListener('iron-ajax-error', incrementTotal);
           var ajax = fixture('Bubbles')[1];
           ajax.generateRequest();
           server.respond();


### PR DESCRIPTION
Makes it so that when `bubbles` is used, `iron-ajax-request`, `iron-ajax-response`, and `iron-ajax-error` events will bubble to `window` while the usual scoped `request`, `response`, and `error` events are still fired.

This is necessary because it seems there is [no way to get the `error` event to escape the shadow dom](https://www.w3.org/TR/shadow-dom/#h-events-that-are-not-leaked-into-ancestor-trees).

Should fix #134.