### PR TITLE
Fix documentation for iron-request

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -16,7 +16,7 @@ iron-request can be used to perform XMLHttpRequests.
 
     <iron-request id="xhr"></iron-request>
     ...
-    this.$.xhr.send({url: url, params: params});
+    this.$.xhr.send({url: url, body: params});
 -->
 <script>
   'use strict';


### PR DESCRIPTION
Docs say to use params `options`, but it seems to use `body` in the actual request.