### PR TITLE
Fixes #203

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -433,7 +433,7 @@ element.
       var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
       var requestOptions = this.toRequestOptions();
 
-      this.activeRequests.push(request);
+      this.push('activeRequests', request);
 
       request.completes.then(
         this._boundHandleResponse
@@ -488,7 +488,7 @@ element.
       var requestIndex = this.activeRequests.indexOf(request);
 
       if (requestIndex > -1) {
-        this.activeRequests.splice(requestIndex, 1);
+        this.splice('activeRequests', requestIndex, 1);
       }
     },
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -186,7 +186,7 @@ iron-request can be used to perform XMLHttpRequests.
      *     url The url to which the request is sent.
      *     method The HTTP method to use, default is GET.
      *     async By default, all requests are sent asynchronously. To send synchronous requests,
-     *         set to true.
+     *         set to false.
      *     body The content for the request body for POST method.
      *     headers HTTP request headers.
      *     handleAs The response type. Default is 'text'.


### PR DESCRIPTION
Fixes #203 by using `Polymer.Base.splice` and `Polymer.Base.push` instead of `Array.prototype.splice` and `Array.prototype.push`.

(Also contains the fix #202.)