### PR TITLE
Add a special case exceptions

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -422,6 +422,9 @@ iron-request can be used to perform XMLHttpRequests.
     _wwwFormUrlEncodePiece: function(str) {
       // Spec says to normalize newlines to \r\n and replace %20 spaces with +.
       // jQuery does this as well, so this is likely to be widely compatible.
+      if (str === null) {
+        return '';
+      }
       return encodeURIComponent(str.toString().replace(/\r?\n/g, '\r\n'))
           .replace(/%20/g, '+');
     },


### PR DESCRIPTION
when input value is null
resolve Uncaught TypeError: Cannot read property 'toString' of null