### PR TITLE
Manage request as an upload

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -323,7 +323,16 @@ element.
         value: function() {
           return this._handleResponse.bind(this);
         }
-      }
+      },
+
+      /**
+       * Manages whether iron-request should listen to this.xhr or this.xhr.upload
+	   * for progress events
+       */
+      isUpload: {
+		type: Boolean,
+		value: false
+	  }
     },
 
     observers: [
@@ -441,6 +450,8 @@ element.
     generateRequest: function() {
       var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
       var requestOptions = this.toRequestOptions();
+
+	  request.isUpload = this.isUpload;
 
       this.push('activeRequests', request);
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -146,7 +146,7 @@ iron-request can be used to perform XMLHttpRequests.
       },
 
       /**
-       * Manages whether iron-request should listen to this.xhr or this.xhr.upload
+       * Manages whether to listen to this.xhr or this.xhr.upload
 	   * for progress events
        */
       isUpload: {

--- a/iron-request.html
+++ b/iron-request.html
@@ -143,7 +143,16 @@ iron-request can be used to perform XMLHttpRequests.
         notify: true,
         readOnly: true,
         value: false
-      }
+      },
+
+      /**
+       * Manages whether iron-request should listen to this.xhr or this.xhr.upload
+	   * for progress events
+       */
+      isUpload: {
+		type: Boolean,
+		value: false
+	  }
     },
 
     /**
@@ -201,13 +210,23 @@ iron-request can be used to perform XMLHttpRequests.
         return null;
       }
 
-      xhr.addEventListener('progress', function (progress) {
-        this._setProgress({
-          lengthComputable: progress.lengthComputable,
-          loaded: progress.loaded,
-          total: progress.total
-        });
-      }.bind(this))
+	  if (this.isUpload) {
+        xhr.upload.addEventListener('progress', function (progress) {
+          this._setProgress({
+            lengthComputable: progress.lengthComputable,
+            loaded: progress.loaded,
+            total: progress.total
+          });
+	    }.bind(this));
+	  } else {
+        xhr.addEventListener('progress', function (progress) {
+          this._setProgress({
+            lengthComputable: progress.lengthComputable,
+            loaded: progress.loaded,
+            total: progress.total
+          });
+	    }.bind(this));
+	  }
 
       xhr.addEventListener('error', function (error) {
         this._setErrored(true);


### PR DESCRIPTION
This is also in reference to #235.

This is a first pass at this PR as I have a number of questions about what form a more complete implementation should be.

Here I've added an `isUpload` property to both the `iron-ajax` and `iron-upload` so that when it is set to `true` the listener in `iron-request` that updates the `progress` property is attached to `xhr.upload` instead of just `xhr`. This allows the implementer to track file uploads into the UI, etc.

First, I'm wondering if when uploading all events tracked in `send()` should be pointed to `xhr.upload`. Second, should this actually be an even greater change where the `progress` object be duplicated into `uploadProgress` and `downloadProgress` so that both objects and listeners can be tracked at all times?

Once that is figured out, I'd look for insight on good ways to add tests for this. There doesn't seem to be any test in `iron-request` for progress, and this seems like it might be a good place to do so?