### PR TITLE
from polymerlabs to PolymerLabs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/PolymerElements/iron-ajax",
   "ignore": [],
   "dependencies": {
-    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
+    "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.0",
     "polymer": "Polymer/polymer#^1.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I checked the the "2.0-preview" branch of this Polymer element and it is already fixed there, so this pull request wants to achieve the same thing in Polymer 1.x for this element.

This pull request is a manual follow up of https://github.com/PolymerLabs/tedium/issues/47 and https://github.com/PolymerLabs/tedium/pull/48 which try to do this in an automated way, but are stuck.