### PR TITLE
dispatch error event only if iron-ajax-error allows it. 

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -498,15 +498,17 @@ element.
       }
 
       // Tests fail if this goes after the normal this.fire('error', ...)
-      this.fire('iron-ajax-error', {
+      var errorEvent = this.fire('iron-ajax-error', {
         request: request,
         error: error
       }, {bubbles: this.bubbles});
 
-      this.fire('error', {
-        request: request,
-        error: error
-      }, {bubbles: this.bubbles});
+      if(!errorEvent.defaultPrevented) {
+        this.fire('error', {
+          request: request,
+          error: error
+        }, {bubbles: this.bubbles});
+      }
     },
 
     _discardRequest: function(request) {


### PR DESCRIPTION
This change adds the ability for listeners of "iron-ajax-error" to prevent "error" event.

    ajaxElement.addEventListener('iron-ajax-error', function (event) {
         event.preventDefault(); // now "error" will never fire.
    })
