### PR TITLE
Adding the request element into the promise chain for error cases

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -318,6 +318,15 @@ element.
         value: false
       },
 
+      /**
+       * Changes the completes promise chain from generateRequest to reject with an object
+       *  containing the error message as well as the request.
+       */
+      rejectWithRequest: {
+        type: Boolean,
+        value: false
+      },
+
       _boundHandleResponse: {
         type: Function,
         value: function() {
@@ -429,7 +438,8 @@ element.
         handleAs: this.handleAs,
         jsonPrefix: this.jsonPrefix,
         withCredentials: this.withCredentials,
-        timeout: this.timeout
+        timeout: this.timeout,
+        rejectWithRequest: this.rejectWithRequest,
       };
     },
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -211,25 +211,32 @@ iron-request can be used to perform XMLHttpRequests.
       xhr.addEventListener('error', function (error) {
         this._setErrored(true);
         this._updateStatus();
-        this.rejectCompletes({
+        var response = options.rejectWithRequest ? {
           error: error,
           request: this
-        });
+        } : error;
+        this.rejectCompletes(response);
       }.bind(this));
 
       xhr.addEventListener('timeout', function (error) {
         this._setTimedOut(true);
         this._updateStatus();
-        this.rejectCompletes({
+        var response = options.rejectWithRequest ? {
           error: error,
           request: this
-        });
+        } : error;
+        this.rejectCompletes(response);
       }.bind(this));
 
       xhr.addEventListener('abort', function () {
         this._setAborted(true);
         this._updateStatus();
-        this.rejectCompletes({request: this});
+        var error = new Error('Request aborted.');
+        var response = options.rejectWithRequest ? {
+          error: error,
+          request: this
+        } : error;
+        this.rejectCompletes(response);
       }.bind(this));
 
       // Called after all of the above.
@@ -238,7 +245,12 @@ iron-request can be used to perform XMLHttpRequests.
         this._setResponse(this.parseResponse());
 
         if (!this.succeeded) {
-          this.rejectCompletes({request: this});
+          var error = new Error('The request failed with status code: ' + this.xhr.status);
+          var response = options.rejectWithRequest ? {
+            error: error,
+            request: this
+          } : error;
+          this.rejectCompletes(response);
           return;
         }
 
@@ -372,10 +384,7 @@ iron-request can be used to perform XMLHttpRequests.
           }
         }
       } catch (e) {
-        this.rejectCompletes({
-          error: new Error('Could not parse response. ' + e.message),
-          request: this
-        });
+        this.rejectCompletes(new Error('Could not parse response. ' + e.message));
       }
     },
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -211,18 +211,25 @@ iron-request can be used to perform XMLHttpRequests.
       xhr.addEventListener('error', function (error) {
         this._setErrored(true);
         this._updateStatus();
-        this.rejectCompletes(error);
+        this.rejectCompletes({
+          error: error,
+          request: this
+        });
       }.bind(this));
 
       xhr.addEventListener('timeout', function (error) {
         this._setTimedOut(true);
         this._updateStatus();
-        this.rejectCompletes(error);
+        this.rejectCompletes({
+          error: error,
+          request: this
+        });
       }.bind(this));
 
       xhr.addEventListener('abort', function () {
+        this._setAborted(true);
         this._updateStatus();
-        this.rejectCompletes(new Error('Request aborted.'));
+        this.rejectCompletes({request: this});
       }.bind(this));
 
       // Called after all of the above.
@@ -231,7 +238,7 @@ iron-request can be used to perform XMLHttpRequests.
         this._setResponse(this.parseResponse());
 
         if (!this.succeeded) {
-          this.rejectCompletes(new Error('The request failed with status code: ' + this.xhr.status));
+          this.rejectCompletes({request: this});
           return;
         }
 
@@ -365,7 +372,10 @@ iron-request can be used to perform XMLHttpRequests.
           }
         }
       } catch (e) {
-        this.rejectCompletes(new Error('Could not parse response. ' + e.message));
+        this.rejectCompletes({
+          error: new Error('Could not parse response. ' + e.message),
+          request: this
+        });
       }
     },
 

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -702,6 +702,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           return promise;
         });
 
+        test('with rejectWithRequest the promise chain contains the request and error', function () {
+          ajax.url = '/responds_to_get_with_502_error_json';
+          ajax.handleAs = 'json';
+          ajax.rejectWithRequest = true;
+
+          var request = ajax.generateRequest();
+          var promise = request.completes.then(function() {
+            throw new Error('Expected the request to fail!');
+          }, function(resp) {
+            expect(resp.error).to.be.instanceof(Error);
+            expect(resp.request).to.deep.equal(request);
+          });
+
+          server.respond();
+
+          return promise;
+        });
+
         test('we give a useful error even when the domain doesn\'t resolve', function() {
           ajax.url = 'http://nonexistant.example.com/';
           server.restore();

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -132,6 +132,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
+        test('can be aborted with request element', function () {
+          var options = {
+            url: successfulRequestOptions.url,
+            rejectWithRequest: true
+          };
+          request.send(options);
+
+          request.abort();
+
+          server.respond();
+
+          return request.completes.then(function () {
+            throw new Error('Request did not abort appropriately!');
+          }).catch(function (e) {
+            expect(e.error).to.be.instanceof(Error);
+            expect(e.request).to.deep.equal(request);
+          });
+        });
+
         test('default responseType is text', function () {
           request.send(successfulRequestOptions);
           server.respond();


### PR DESCRIPTION
Right now there's just an error object being passed along to the promise chain for error cases, this updates to returning an object that will contain that same error as a property as well as the request object.  Needed to support use-cases that have error codes coming back from the API call to give details on the error that occurred without adding extra work to handle the error case via events while the success case is a promise chain.

This is a breaking change, hoping to get it in as part of the 2.0 release, this is here to spark discussions on the concept, will follow up with tests once a strategy is decided on.

TODO:

- [ ] unit tests

This PR addresses #257 and removes the need for a work-around.
@rictic @cdata 