### PR TITLE
Adds console warning for failed JSON.parse calls. Addresses #224

### DIFF
--- a/iron-request.html
+++ b/iron-request.html
@@ -356,6 +356,7 @@ iron-request can be used to perform XMLHttpRequests.
               try {
                 return JSON.parse(xhr.responseText);
               } catch (_) {
+                console.warn('Failed to parse JSON sent from ' + xhr.responseUrl);
                 return null;
               }
             }
@@ -377,6 +378,7 @@ iron-request can be used to perform XMLHttpRequests.
               try {
                 return JSON.parse(xhr.responseText.substring(prefixLen));
               } catch (_) {
+                console.warn('Failed to parse JSON sent from ' + xhr.responseUrl);
                 return null;
               }
             }


### PR DESCRIPTION
JSON.parse silently fails. This makes it hard to debug why something isn't working. Hopefully adding a console warning will help.