### PR TITLE
from polymerlabs to PolymerLabs (again)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,9 +23,9 @@
     "polymer": "Polymer/polymer#1.9 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#1 - 2",
-    "iron-image": "polymerelements/iron-image#1 - 2",
-    "promise-polyfill": "polymerlabs/promise-polyfill#1 - 2",
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
+    "iron-image": "PolymerElements/iron-image#1 - 2",
+    "promise-polyfill": "PolymerLabs/promise-polyfill#1 - 2",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
     "web-component-tester": "^6.0.0"
@@ -33,14 +33,14 @@
   "variants": {
     "1.x": {
       "dependencies": {
-        "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
+        "promise-polyfill": "PolymerLabs/promise-polyfill#^1.0.0",
         "polymer": "Polymer/polymer#^1.9"
       },
       "devDependencies": {
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-        "iron-image": "polymerelements/iron-image#^1.0.0",
-        "paper-styles": "polymerelements/paper-styles#^1.0.0",
-        "test-fixture": "polymerelements/test-fixture#^1.0.0",
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-image": "PolymerElements/iron-image#^1.0.0",
+        "paper-styles": "PolymerElements/paper-styles#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "web-component-tester": "^4.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },


### PR DESCRIPTION
This pull request is similar to #251 which I have closed. This updated version not only fixes the main dependency in the 1.x variant but also all "devDependencies" as well.

The rational for this pull request is:

This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.