### PR TITLE
Fix return type typo of iron-ajax.generateRequest().

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -454,10 +454,10 @@ element.
     /**
      * Performs an AJAX request to the specified URL.
      *
-     * @return {!IronRequestElement}
+     * @return {IronRequestElement}
      */
     generateRequest: function() {
-      var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
+      var request = /** @type {IronRequestElement} */ (document.createElement('iron-request'));
       var requestOptions = this.toRequestOptions();
 
       this.push('activeRequests', request);


### PR DESCRIPTION
This also affects iron-ajax's API doc on [webcomponents.org](https://www.webcomponents.org/element/PolymerElements/iron-ajax/elements/iron-ajax).