### PR TITLE
duplicate event annotations for jsdoc validity

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -53,6 +53,11 @@ element.
      * Fired when a request is sent.
      *
      * @event request
+     */
+
+    /**
+     * Fired when a request is sent.
+     *
      * @event iron-ajax-request
      */
 
@@ -60,6 +65,11 @@ element.
      * Fired when a response is received.
      *
      * @event response
+     */
+
+    /**
+     * Fired when a response is received.
+     *
      * @event iron-ajax-response
      */
 
@@ -67,6 +77,11 @@ element.
      * Fired when an error is received.
      *
      * @event error
+     */
+
+    /**
+     * Fired when an error is received.
+     *
      * @event iron-ajax-error
      */
 


### PR DESCRIPTION
This addresses an issue we had over at polymer/polymer-analyzer#404.

We figured having multiple events in a single annotation isn't really standard, so are fixing it up here instead of in the scanners.