### PR TITLE
fix some missing variables

### DIFF
--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -31,6 +31,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var successfulRequestOptions;
       var request;
       var server;
+      var synchronousSuccessfulRequestOptions;
+      var asynchronousSuccessfulRequestOptions;
+      var asynchronousUndefSuccessfulRequestOptions;
 
       setup(function() {
         jsonResponseHeaders = {


### PR DESCRIPTION
This makes iron-request work with the modulizer.

If this isn't the right place to fix it, i will close. However, this is a clear error any linter would pick up so we should probably resolve it regardless.