### PR TITLE
Fix responseURL reference, and make some types nullable.

### DIFF
--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -243,6 +243,8 @@ element.
 
       /**
        * The most recent request made by this iron-ajax element.
+       *
+       * @type {Object}
        */
       lastRequest: {
         type: Object,
@@ -252,6 +254,8 @@ element.
 
       /**
        * The `progress` property of this element's `lastRequest`.
+       *
+       * @type {Object}
        */
       lastProgress: {
         type: Object,

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -244,7 +244,7 @@ element.
       /**
        * The most recent request made by this iron-ajax element.
        *
-       * @type {Object}
+       * @type {Object|undefined}
        */
       lastRequest: {
         type: Object,
@@ -255,7 +255,7 @@ element.
       /**
        * The `progress` property of this element's `lastRequest`.
        *
-       * @type {Object}
+       * @type {Object|undefined}
        */
       lastProgress: {
         type: Object,

--- a/iron-request.html
+++ b/iron-request.html
@@ -367,7 +367,7 @@ iron-request can be used to perform XMLHttpRequests.
               try {
                 return JSON.parse(xhr.responseText);
               } catch (_) {
-                console.warn('Failed to parse JSON sent from ' + xhr.responseUrl);
+                console.warn('Failed to parse JSON sent from ' + xhr.responseURL);
                 return null;
               }
             }
@@ -389,7 +389,7 @@ iron-request can be used to perform XMLHttpRequests.
               try {
                 return JSON.parse(xhr.responseText.substring(prefixLen));
               } catch (_) {
-                console.warn('Failed to parse JSON sent from ' + xhr.responseUrl);
+                console.warn('Failed to parse JSON sent from ' + xhr.responseURL);
                 return null;
               }
             }


### PR DESCRIPTION
- `responseUrl` -> `responseURL` (https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseURL)
- Add `@type {Object}` annotations to some properties that are possibly `null`. When a Polymer property type is inferred by the Closure Polymer Pass using the `type` property field, it will make it non-nullable (e.g. `!Object` in this case). We need it to be nullable (which is, confusingly, the default in Closure, hence no `!` in the type annotation).