### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
     npm run update-types && git diff --exit-code || (echo -e
     '\n\033[31mERROR:\033[0m Typings are stale. Please run "npm run
     update-types".' && false)
+  - >-
+    npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+    Typings are stale. Please run "npm run format".' && false)
 env:
   global:
     - secure: >-

--- a/iron-ajax.d.ts
+++ b/iron-ajax.d.ts
@@ -183,7 +183,8 @@ interface IronAjaxElement extends Polymer.Element {
   readonly activeRequests: any[]|null|undefined;
 
   /**
-   * Length of time in milliseconds to debounce multiple automatically generated requests.
+   * Length of time in milliseconds to debounce multiple automatically
+   * generated requests.
    */
   debounceDuration: number|null|undefined;
 
@@ -198,12 +199,13 @@ interface IronAjaxElement extends Polymer.Element {
   jsonPrefix: string|null|undefined;
 
   /**
-   * By default, iron-ajax's events do not bubble. Setting this attribute will cause its
-   * request and response events as well as its iron-ajax-request, -response,  and -error
-   * events to bubble to the window object. The vanilla error event never bubbles when
-   * using shadow dom even if this.bubbles is true because a scoped flag is not passed with
-   * it (first link) and because the shadow dom spec did not used to allow certain events,
-   * including events named error, to leak outside of shadow trees (second link).
+   * By default, iron-ajax's events do not bubble. Setting this attribute will
+   * cause its request and response events as well as its iron-ajax-request,
+   * -response,  and -error events to bubble to the window object. The vanilla
+   * error event never bubbles when using shadow dom even if this.bubbles is
+   * true because a scoped flag is not passed with it (first link) and because
+   * the shadow dom spec did not used to allow certain events, including
+   * events named error, to leak outside of shadow trees (second link).
    * https://www.w3.org/TR/shadow-dom/#scoped-flag
    * https://www.w3.org/TR/2015/WD-shadow-dom-20151215/#events-that-are-not-leaked-into-ancestor-trees
    */

--- a/iron-ajax.html
+++ b/iron-ajax.html
@@ -85,17 +85,13 @@ element.
      * @event iron-ajax-error
      */
 
-    hostAttributes: {
-      hidden: true
-    },
+    hostAttributes: {hidden: true},
 
     properties: {
       /**
        * The URL target of the request.
        */
-      url: {
-        type: String
-      },
+      url: {type: String},
 
       /**
        * An object that contains query parameters to be appended to the
@@ -114,10 +110,7 @@ element.
        * The HTTP method to use such as 'GET', 'POST', 'PUT', or 'DELETE'.
        * Default is 'GET'.
        */
-      method: {
-        type: String,
-        value: 'GET'
-      },
+      method: {type: String, value: 'GET'},
 
       /**
        * HTTP request headers to send.
@@ -147,10 +140,7 @@ element.
        *
        * Varies the handling of the `body` param.
        */
-      contentType: {
-        type: String,
-        value: null
-      },
+      contentType: {type: String, value: null},
 
       /**
        * Body content to send with the request, typically used with "POST"
@@ -169,21 +159,16 @@ element.
        * Otherwise the body will be passed to the browser unmodified, and it
        * will handle any encoding (e.g. for FormData, Blob, ArrayBuffer).
        *
-       * @type (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object)
+       * @type
+       * (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object)
        */
-      body: {
-        type: Object,
-        value: null
-      },
+      body: {type: Object, value: null},
 
       /**
        * Toggle whether XHR is synchronous or asynchronous. Don't change this
        * to true unless You Know What You Are Doing™.
        */
-      sync: {
-        type: Boolean,
-        value: false
-      },
+      sync: {type: Boolean, value: false},
 
       /**
        * Specifies what data to store in the `response` property, and
@@ -203,74 +188,47 @@ element.
        *
        *    `document`: uses `XHR.response`.
        */
-      handleAs: {
-        type: String,
-        value: 'json'
-      },
+      handleAs: {type: String, value: 'json'},
 
       /**
        * Set the withCredentials flag on the request.
        */
-      withCredentials: {
-        type: Boolean,
-        value: false
-      },
+      withCredentials: {type: Boolean, value: false},
 
       /**
        * Set the timeout flag on the request.
        */
-      timeout: {
-        type: Number,
-        value: 0
-      },
+      timeout: {type: Number, value: 0},
 
       /**
        * If true, automatically performs an Ajax request when either `url` or
        * `params` changes.
        */
-      auto: {
-        type: Boolean,
-        value: false
-      },
+      auto: {type: Boolean, value: false},
 
       /**
        * If true, error messages will automatically be logged to the console.
        */
-      verbose: {
-        type: Boolean,
-        value: false
-      },
+      verbose: {type: Boolean, value: false},
 
       /**
        * The most recent request made by this iron-ajax element.
        *
        * @type {Object|undefined}
        */
-      lastRequest: {
-        type: Object,
-        notify: true,
-        readOnly: true
-      },
+      lastRequest: {type: Object, notify: true, readOnly: true},
 
       /**
        * The `progress` property of this element's `lastRequest`.
        *
        * @type {Object|undefined}
        */
-      lastProgress: {
-        type: Object,
-        notify: true,
-        readOnly: true
-      },
+      lastProgress: {type: Object, notify: true, readOnly: true},
 
       /**
        * True while lastRequest is in flight.
        */
-      loading: {
-        type: Boolean,
-        notify: true,
-        readOnly: true
-      },
+      loading: {type: Boolean, notify: true, readOnly: true},
 
       /**
        * lastRequest's response.
@@ -284,22 +242,14 @@ element.
        *
        * @type {Object}
        */
-      lastResponse: {
-        type: Object,
-        notify: true,
-        readOnly: true
-      },
+      lastResponse: {type: Object, notify: true, readOnly: true},
 
       /**
        * lastRequest's error, if any.
        *
        * @type {Object}
        */
-      lastError: {
-        type: Object,
-        notify: true,
-        readOnly: true
-      },
+      lastError: {type: Object, notify: true, readOnly: true},
 
       /**
        * An Array of all in-flight requests originating from this iron-ajax
@@ -315,13 +265,10 @@ element.
       },
 
       /**
-       * Length of time in milliseconds to debounce multiple automatically generated requests.
+       * Length of time in milliseconds to debounce multiple automatically
+       * generated requests.
        */
-      debounceDuration: {
-        type: Number,
-        value: 0,
-        notify: true
-      },
+      debounceDuration: {type: Number, value: 0, notify: true},
 
       /**
        * Prefix to be stripped from a JSON response before parsing it.
@@ -332,36 +279,28 @@ element.
        * with a string that would be nonsensical to a JavaScript parser.
        *
        */
-      jsonPrefix: {
-        type: String,
-        value: ''
-      },
+      jsonPrefix: {type: String, value: ''},
 
       /**
-       * By default, iron-ajax's events do not bubble. Setting this attribute will cause its
-       * request and response events as well as its iron-ajax-request, -response,  and -error
-       * events to bubble to the window object. The vanilla error event never bubbles when
-       * using shadow dom even if this.bubbles is true because a scoped flag is not passed with
-       * it (first link) and because the shadow dom spec did not used to allow certain events,
-       * including events named error, to leak outside of shadow trees (second link).
+       * By default, iron-ajax's events do not bubble. Setting this attribute will
+       * cause its request and response events as well as its iron-ajax-request,
+       * -response,  and -error events to bubble to the window object. The vanilla
+       * error event never bubbles when using shadow dom even if this.bubbles is
+       * true because a scoped flag is not passed with it (first link) and because
+       * the shadow dom spec did not used to allow certain events, including
+       * events named error, to leak outside of shadow trees (second link).
        * https://www.w3.org/TR/shadow-dom/#scoped-flag
        * https://www.w3.org/TR/2015/WD-shadow-dom-20151215/#events-that-are-not-leaked-into-ancestor-trees
        */
-      bubbles: {
-        type: Boolean,
-        value: false
-      },
+      bubbles: {type: Boolean, value: false},
 
       /**
-       * Changes the [`completes`](iron-request#property-completes) promise chain 
+       * Changes the [`completes`](iron-request#property-completes) promise chain
        * from `generateRequest` to reject with an object
        * containing the original request, as well an error message.
        * If false (default), the promise rejects with an error message only.
        */
-      rejectWithRequest: {
-        type: Boolean,
-        value: false
-      },
+      rejectWithRequest: {type: Boolean, value: false},
 
       _boundHandleResponse: {
         type: Function,
@@ -371,10 +310,9 @@ element.
       }
     },
 
-    observers: [
-      '_requestOptionsChanged(url, method, params.*, headers, contentType, ' +
-          'body, sync, handleAs, jsonPrefix, withCredentials, timeout, auto)'
-    ],
+    observers:
+        ['_requestOptionsChanged(url, method, params.*, headers, contentType, ' +
+         'body, sync, handleAs, jsonPrefix, withCredentials, timeout, auto)'],
 
     created: function() {
       this._boundOnProgressChanged = this._onProgressChanged.bind(this);
@@ -386,7 +324,7 @@ element.
      *
      * @return {string}
      */
-    get queryString () {
+    get queryString() {
       var queryParts = [];
       var param;
       var value;
@@ -466,7 +404,8 @@ element.
      *   url: string,
      *   method: (string|undefined),
      *   async: (boolean|undefined),
-     *   body: (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object),
+     *   body:
+     * (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object),
      *   headers: (Object|undefined),
      *   handleAs: (string|undefined),
      *   jsonPrefix: (string|undefined),
@@ -493,23 +432,20 @@ element.
      * @return {!IronRequestElement}
      */
     generateRequest: function() {
-      var request = /** @type {!IronRequestElement} */ (document.createElement('iron-request'));
+      var request = /** @type {!IronRequestElement} */ (
+          document.createElement('iron-request'));
       var requestOptions = this.toRequestOptions();
 
       this.push('activeRequests', request);
 
-      request.completes.then(
-        this._boundHandleResponse
-      ).catch(
-        this._handleError.bind(this, request)
-      ).then(
-        this._discardRequest.bind(this, request)
-      );
+      request.completes.then(this._boundHandleResponse)
+          .catch(this._handleError.bind(this, request))
+          .then(this._discardRequest.bind(this, request));
 
-      var evt = this.fire('iron-ajax-presend', {
-        request: request,
-        options: requestOptions
-      }, {bubbles: this.bubbles, cancelable: true});
+      var evt = this.fire(
+          'iron-ajax-presend',
+          {request: request, options: requestOptions},
+          {bubbles: this.bubbles, cancelable: true});
 
       if (evt.defaultPrevented) {
         request.abort();
@@ -518,33 +454,27 @@ element.
       }
 
       if (this.lastRequest) {
-        this.lastRequest.removeEventListener('iron-request-progress-changed',
-                this._boundOnProgressChanged);
+        this.lastRequest.removeEventListener(
+            'iron-request-progress-changed', this._boundOnProgressChanged);
       }
 
-      request.addEventListener('iron-request-progress-changed',
-          this._boundOnProgressChanged);
+      request.addEventListener(
+          'iron-request-progress-changed', this._boundOnProgressChanged);
 
       request.send(requestOptions);
       this._setLastProgress(null);
       this._setLastRequest(request);
       this._setLoading(true);
 
-      this.fire('request', {
-        request: request,
-        options: requestOptions
-      }, {
-        bubbles: this.bubbles,
-        composed: true
-      });
+      this.fire(
+          'request',
+          {request: request, options: requestOptions},
+          {bubbles: this.bubbles, composed: true});
 
-      this.fire('iron-ajax-request', {
-        request: request,
-        options: requestOptions
-      }, {
-        bubbles: this.bubbles,
-        composed: true
-      });
+      this.fire(
+          'iron-ajax-request',
+          {request: request, options: requestOptions},
+          {bubbles: this.bubbles, composed: true});
 
       return request;
     },
@@ -555,14 +485,9 @@ element.
         this._setLastError(null);
         this._setLoading(false);
       }
-      this.fire('response', request, {
-        bubbles: this.bubbles,
-        composed: true
-      });
-      this.fire('iron-ajax-response', request, {
-        bubbles: this.bubbles,
-        composed: true
-      });
+      this.fire('response', request, {bubbles: this.bubbles, composed: true});
+      this.fire(
+          'iron-ajax-response', request, {bubbles: this.bubbles, composed: true});
     },
 
     _handleError: function(request, error) {
@@ -583,21 +508,15 @@ element.
       }
 
       // Tests fail if this goes after the normal this.fire('error', ...)
-      this.fire('iron-ajax-error', {
-        request: request,
-        error: error
-      }, {
-        bubbles: this.bubbles,
-        composed: true
-      });
+      this.fire(
+          'iron-ajax-error',
+          {request: request, error: error},
+          {bubbles: this.bubbles, composed: true});
 
-      this.fire('error', {
-        request: request,
-        error: error
-      }, {
-        bubbles: this.bubbles,
-        composed: true
-      });
+      this.fire(
+          'error',
+          {request: request, error: error},
+          {bubbles: this.bubbles, composed: true});
     },
 
     _discardRequest: function(request) {

--- a/iron-request.d.ts
+++ b/iron-request.d.ts
@@ -86,22 +86,24 @@ interface IronRequestElement extends Polymer.Element {
   readonly succeeded: boolean;
 
   /**
-   * Sends an HTTP request to the server and returns a promise (see the `completes`
-   * property for details).
+   * Sends an HTTP request to the server and returns a promise (see the
+   * `completes` property for details).
    *
    * The handling of the `body` parameter will vary based on the Content-Type
    * header. See the docs for iron-ajax's `body` property for details.
    *
    * @param options   - url The url to which the request is sent.
    *   - method The HTTP method to use, default is GET.
-   *   - async By default, all requests are sent asynchronously. To send synchronous requests,
-   *         set to false.
+   *   - async By default, all requests are sent asynchronously. To send
+   * synchronous requests, set to false.
    *   -  body The content for the request body for POST method.
    *   -  headers HTTP request headers.
    *   -  handleAs The response type. Default is 'text'.
-   *   -  withCredentials Whether or not to send credentials on the request. Default is false.
+   *   -  withCredentials Whether or not to send credentials on the request.
+   * Default is false.
    *   -  timeout - Timeout for request, in milliseconds.
-   *   -  rejectWithRequest Set to true to include the request object with promise rejections.
+   *   -  rejectWithRequest Set to true to include the request object with
+   * promise rejections.
    */
   send(options: {url: string, method?: string, async?: boolean, body?: ArrayBuffer|ArrayBufferView|Blob|Document|FormData|string|object|null, headers?: object|null, handleAs?: string, jsonPrefix?: string, withCredentials?: boolean, timeout?: Number|null, rejectWithRequest?: boolean}): Promise<any>|null;
 

--- a/iron-request.html
+++ b/iron-request.html
@@ -23,9 +23,7 @@ iron-request can be used to perform XMLHttpRequests.
   Polymer({
     is: 'iron-request',
 
-    hostAttributes: {
-      hidden: true
-    },
+    hostAttributes: {hidden: true},
 
     properties: {
 
@@ -63,22 +61,12 @@ iron-request can be used to perform XMLHttpRequests.
       /**
        * A reference to the status code, if the `xhr` has completely resolved.
        */
-      status: {
-        type: Number,
-        notify: true,
-        readOnly: true,
-        value: 0
-      },
+      status: {type: Number, notify: true, readOnly: true, value: 0},
 
       /**
        * A reference to the status text, if the `xhr` has completely resolved.
        */
-      statusText: {
-        type: String,
-        notify: true,
-        readOnly: true,
-        value: ''
-      },
+      statusText: {type: String, notify: true, readOnly: true, value: ''},
 
       /**
        * A promise that resolves when the `xhr` response comes back, or rejects
@@ -132,22 +120,12 @@ iron-request can be used to perform XMLHttpRequests.
        * Errored will be true if the browser fired an error event from the
        * XHR object (mainly network errors).
        */
-      errored: {
-        type: Boolean,
-        notify: true,
-        readOnly: true,
-        value: false
-      },
+      errored: {type: Boolean, notify: true, readOnly: true, value: false},
 
       /**
        * TimedOut will be true if the XHR threw a timeout event.
        */
-      timedOut: {
-        type: Boolean,
-        notify: true,
-        readOnly: true,
-        value: false
-      }
+      timedOut: {type: Boolean, notify: true, readOnly: true, value: false}
     },
 
     /**
@@ -168,13 +146,12 @@ iron-request can be used to perform XMLHttpRequests.
 
       // Note: if we are using the file:// protocol, the status code will be 0
       // for all outcomes (successful or otherwise).
-      return status === 0 ||
-        (status >= 200 && status < 300);
+      return status === 0 || (status >= 200 && status < 300);
     },
 
     /**
-     * Sends an HTTP request to the server and returns a promise (see the `completes`
-     * property for details).
+     * Sends an HTTP request to the server and returns a promise (see the
+     * `completes` property for details).
      *
      * The handling of the `body` parameter will vary based on the Content-Type
      * header. See the docs for iron-ajax's `body` property for details.
@@ -183,7 +160,8 @@ iron-request can be used to perform XMLHttpRequests.
      *   url: string,
      *   method: (string|undefined),
      *   async: (boolean|undefined),
-     *   body: (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object),
+     *   body:
+     * (ArrayBuffer|ArrayBufferView|Blob|Document|FormData|null|string|undefined|Object),
      *   headers: (Object|undefined),
      *   handleAs: (string|undefined),
      *   jsonPrefix: (string|undefined),
@@ -192,14 +170,16 @@ iron-request can be used to perform XMLHttpRequests.
      *   rejectWithRequest: (boolean|undefined)}} options -
      *   - url The url to which the request is sent.
      *   - method The HTTP method to use, default is GET.
-     *   - async By default, all requests are sent asynchronously. To send synchronous requests,
-     *         set to false.
+     *   - async By default, all requests are sent asynchronously. To send
+     * synchronous requests, set to false.
      *   -  body The content for the request body for POST method.
      *   -  headers HTTP request headers.
      *   -  handleAs The response type. Default is 'text'.
-     *   -  withCredentials Whether or not to send credentials on the request. Default is false.
+     *   -  withCredentials Whether or not to send credentials on the request.
+     * Default is false.
      *   -  timeout - Timeout for request, in milliseconds.
-     *   -  rejectWithRequest Set to true to include the request object with promise rejections.
+     *   -  rejectWithRequest Set to true to include the request object with
+     * promise rejections.
      * @return {Promise}
      */
     send: function(options) {
@@ -217,26 +197,22 @@ iron-request can be used to perform XMLHttpRequests.
         });
 
         // Webcomponents v1 spec does not fire *-changed events when not connected
-        this.fire('iron-request-progress-changed', { value: this.progress });
+        this.fire('iron-request-progress-changed', {value: this.progress});
       }.bind(this))
 
       xhr.addEventListener('error', function(error) {
         this._setErrored(true);
         this._updateStatus();
-        var response = options.rejectWithRequest ? {
-          error: error,
-          request: this
-        } : error;
+        var response =
+            options.rejectWithRequest ? {error: error, request: this} : error;
         this.rejectCompletes(response);
       }.bind(this));
 
       xhr.addEventListener('timeout', function(error) {
         this._setTimedOut(true);
         this._updateStatus();
-        var response = options.rejectWithRequest ? {
-          error: error,
-          request: this
-        } : error;
+        var response =
+            options.rejectWithRequest ? {error: error, request: this} : error;
         this.rejectCompletes(response);
       }.bind(this));
 
@@ -244,10 +220,8 @@ iron-request can be used to perform XMLHttpRequests.
         this._setAborted(true);
         this._updateStatus();
         var error = new Error('Request aborted.');
-        var response = options.rejectWithRequest ? {
-          error: error,
-          request: this
-        } : error;
+        var response =
+            options.rejectWithRequest ? {error: error, request: this} : error;
         this.rejectCompletes(response);
       }.bind(this));
 
@@ -257,11 +231,10 @@ iron-request can be used to perform XMLHttpRequests.
         this._setResponse(this.parseResponse());
 
         if (!this.succeeded) {
-          var error = new Error('The request failed with status code: ' + this.xhr.status);
-          var response = options.rejectWithRequest ? {
-            error: error,
-            request: this
-          } : error;
+          var error = new Error(
+              'The request failed with status code: ' + this.xhr.status);
+          var response =
+              options.rejectWithRequest ? {error: error, request: this} : error;
           this.rejectCompletes(response);
           return;
         }
@@ -271,11 +244,7 @@ iron-request can be used to perform XMLHttpRequests.
 
       this.url = options.url;
       var isXHRAsync = options.async !== false;
-      xhr.open(
-        options.method || 'GET',
-        options.url,
-        isXHRAsync
-      );
+      xhr.open(options.method || 'GET', options.url, isXHRAsync);
 
       var acceptType = {
         'json': 'application/json',
@@ -298,10 +267,7 @@ iron-request can be used to perform XMLHttpRequests.
         if (/[A-Z]/.test(requestHeader)) {
           Polymer.Base._error('Headers must be lower case, got', requestHeader);
         }
-        xhr.setRequestHeader(
-          requestHeader,
-          headers[requestHeader]
-        );
+        xhr.setRequestHeader(requestHeader, headers[requestHeader]);
       }, this);
 
       if (isXHRAsync) {
@@ -331,9 +297,11 @@ iron-request can be used to perform XMLHttpRequests.
       var body = this._encodeBodyObject(options.body, headers['content-type']);
 
       xhr.send(
-        /** @type {ArrayBuffer|ArrayBufferView|Blob|Document|FormData|
-                   null|string|undefined} */
-        (body));
+          /**
+             @type {ArrayBuffer|ArrayBufferView|Blob|Document|FormData|
+                     null|string|undefined}
+           */
+          (body));
 
       return this.completes;
     },
@@ -421,10 +389,10 @@ iron-request can be used to perform XMLHttpRequests.
         return body;  // Already encoded.
       }
       var bodyObj = /** @type {Object} */ (body);
-      switch(contentType) {
-        case('application/json'):
+      switch (contentType) {
+        case ('application/json'):
           return JSON.stringify(bodyObj);
-        case('application/x-www-form-urlencoded'):
+        case ('application/x-www-form-urlencoded'):
           return this._wwwFormUrlEncode(bodyObj);
       }
       return body;
@@ -461,7 +429,7 @@ iron-request can be used to perform XMLHttpRequests.
       }
 
       return encodeURIComponent(str.toString().replace(/\r?\n/g, '\r\n'))
-        .replace(/%20/g, '+');
+          .replace(/%20/g, '+');
     },
 
     /**
@@ -469,7 +437,8 @@ iron-request can be used to perform XMLHttpRequests.
      */
     _updateStatus: function() {
       this._setStatus(this.xhr.status);
-      this._setStatusText((this.xhr.statusText === undefined) ? '' : this.xhr.statusText);
+      this._setStatusText(
+          (this.xhr.statusText === undefined) ? '' : this.xhr.statusText);
     }
   });
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,23 +3,34 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
+      }
+    },
     "@polymer/gen-typescript-declarations": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.0.tgz",
-      "integrity": "sha512-a5DFXI3TdZSVOMH4608LVaBLmcr+mwM2+B8OSBiB9WFNCtdqzUXwtB5We6vBzrThXlO4uRo7d2pEqjNXMAlEkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@polymer/gen-typescript-declarations/-/gen-typescript-declarations-1.2.2.tgz",
+      "integrity": "sha512-9P946+nIkSm+761v3oxH/QVgJozhsInldKY3h8AVstdXkA8W0Fij84pqsFv1nrRuPGj4Pv71crzoZpFnLkNmKQ==",
       "dev": true,
       "requires": {
         "@types/doctrine": "0.0.3",
-        "@types/fs-extra": "5.0.0",
+        "@types/fs-extra": "5.0.1",
         "@types/glob": "5.0.35",
         "command-line-args": "5.0.2",
-        "command-line-usage": "4.1.0",
+        "command-line-usage": "5.0.4",
         "doctrine": "2.1.0",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "fs-extra": "5.0.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "polymer-analyzer": "3.0.0-pre.12"
+        "polymer-analyzer": "3.0.0-pre.14",
+        "vscode-uri": "1.0.3"
       }
     },
     "@types/babel-generator": {
@@ -95,18 +106,18 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
       }
     },
     "@types/glob": {
@@ -115,10 +126,16 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
       }
+    },
+    "@types/is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -127,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.3.tgz",
+      "integrity": "sha512-igaEysRgtg5tYJVIdQ1T2lJ3G6OmoY7g0YVWKHLFiVs4YUChd9IRSiLoHSLffwut+CpsHHBDj4vRxxNEMstctw==",
       "dev": true
     },
     "@types/parse5": {
@@ -138,25 +155,25 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
+        "@types/node": "9.6.3"
+      }
+    },
+    "@types/resolve": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.6.tgz",
+      "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.6.3"
       }
     },
     "@types/winston": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
-      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.9.tgz",
+      "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.6"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
+        "@types/node": "9.6.3"
       }
     },
     "ansi-regex": {
@@ -166,10 +183,13 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
@@ -181,6 +201,24 @@
         "find-replace": "2.0.1"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
@@ -190,19 +228,37 @@
         "typical": "2.6.1"
       }
     },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "async": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
       "dev": true
     },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+      "dev": true
+    },
     "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz",
+      "integrity": "sha512-flMsJ9eSpShupt2Gwpka84DoMePvE4HlDObzdEc+1iNkacv3+NHlsJ7dMKmbnVA/AT22UhcGEBHwbJLoXWBO6Q==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.2",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -221,6 +277,47 @@
         "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.5",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.3.tgz",
+      "integrity": "sha512-iMWYqwDarQOVlEGcK1MfbtK9vrFGs5Z4UQsdASJUHdhBp918EM5kndwriiIbhUX8gr2B/CEV/udJkFTrHsjdMQ==",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "7.0.0-beta.3",
+        "babel-template": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.3.tgz",
+      "integrity": "sha512-ZkYFRMWKx1c9fUW72YNM3eieBG701CMbLjmLLWmJTTPc0F0kddS9Fwok26EAmndUAgD6kFdh7ms3PH94MdGuGQ==",
+      "dev": true,
+      "requires": {
+        "babel-types": "7.0.0-beta.3"
       }
     },
     "babel-messages": {
@@ -238,43 +335,78 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
+        "core-js": "2.5.5",
         "regenerator-runtime": "0.11.1"
       }
     },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+    "babel-template": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.3.tgz",
+      "integrity": "sha512-urJduLja89kSDGqY8ryw8iIwQnMl30IvhMtMNmDD7vBX0l0oylaLgK+7df/9ODX9vR/PhXuif6HYl5HlzAKXMg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
         "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.3.tgz",
+      "integrity": "sha512-xyh/aPYuedMAfQlSj2kjHjsEmY5/Dpxs576L05DySAVMrV+ADX6l4mTOLysAEGwJfkePJlDLhFuS6SKaxv1V7w==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "7.0.0-beta.3",
+        "babel-helper-function-name": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.27",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.27",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.27.tgz",
+          "integrity": "sha512-ksRx+r8eFIfdt63MCgLc9VxGL7W3jcyveQvMpNMVHgW+eb9mq3Xbm45FLCNkw8h92RvoNp4uuiwzcCEwxjDBZg==",
+          "dev": true
+        }
       }
     },
     "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+      "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
       "dev": true
     },
     "balanced-match": {
@@ -283,10 +415,65 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo=",
       "dev": true
     },
     "brace-expansion": {
@@ -299,23 +486,157 @@
         "concat-map": "0.0.1"
       }
     },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.2",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "cancel-token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
+      "dev": true,
+      "requires": {
+        "@types/node": "4.2.23"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "5.3.0"
+      }
+    },
+    "clang-format": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.2.3.tgz",
+      "integrity": "sha512-x90Hac4ERacGDcZSvHKK58Ga0STuMD+Doi5g0iG2zf7wlJef5Huvhs/3BvMRFxwRYyYSdl6mpQNrtfMxE8MQzw==",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.7.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
@@ -338,16 +659,22 @@
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-h17lBwC5bl5RdukPbXji75+cg2/Qbny6kGsmLoy34s9DNH90RwRvJKb+VU5j4YY9HzYl7twLaOWDJQ4b9U+p/Q==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
-        "table-layout": "0.4.2",
+        "chalk": "2.3.2",
+        "table-layout": "0.4.3",
         "typical": "2.6.1"
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -355,10 +682,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
     "cssbeautify": {
@@ -374,13 +707,19 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
@@ -393,6 +732,47 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -419,7 +799,7 @@
       "dev": true,
       "requires": {
         "@types/parse5": "2.2.34",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "parse5": "4.0.0"
       }
     },
@@ -430,16 +810,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -460,17 +840,183 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
     "eyes": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-glob": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
+      "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.1",
+        "micromatch": "3.1.10"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
     },
     "find-replace": {
       "version": "2.0.1",
@@ -480,6 +1026,21 @@
       "requires": {
         "array-back": "2.0.0",
         "test-value": "3.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "0.2.2"
       }
     },
     "fs-extra": {
@@ -499,6 +1060,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -513,10 +1080,37 @@
         "path-is-absolute": "1.0.1"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
       "dev": true
     },
     "graceful-fs": {
@@ -532,6 +1126,44 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
       }
     },
     "indent": {
@@ -557,13 +1189,90 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -573,6 +1282,79 @@
       "requires": {
         "number-is-nan": "1.0.1"
       }
+    },
+    "is-glob": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -602,9 +1384,15 @@
       }
     },
     "jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
     "levn": {
@@ -635,6 +1423,12 @@
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
@@ -642,6 +1436,48 @@
       "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "merge2": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
+      "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.9",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "minimatch": {
@@ -662,17 +1498,107 @@
         "minimatch": "3.0.4"
       }
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -703,10 +1629,34 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "plylog": {
@@ -716,8 +1666,8 @@
       "dev": true,
       "requires": {
         "@types/node": "4.2.23",
-        "@types/winston": "2.3.8",
-        "winston": "2.4.0"
+        "@types/winston": "2.3.9",
+        "winston": "2.4.1"
       },
       "dependencies": {
         "@types/node": {
@@ -729,9 +1679,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.12",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
-      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "version": "3.0.0-pre.14",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.14.tgz",
+      "integrity": "sha512-1Zh/smUWMrjBB7NFUk8i7EAnjO81PqhI0/RzMMy9VgAbPQ6jOROwFX71T02CgpkZYa0O66Ybl7G3+4+0S1aF1Q==",
       "dev": true,
       "requires": {
         "@types/babel-generator": "6.25.1",
@@ -743,27 +1693,34 @@
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
+        "@types/is-windows": "0.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.105",
         "@types/parse5": "2.2.34",
+        "@types/resolve": "0.0.6",
         "babel-generator": "6.26.1",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
+        "babel-traverse": "7.0.0-beta.3",
+        "babel-types": "7.0.0-beta.3",
+        "babylon": "7.0.0-beta.44",
+        "cancel-token": "0.1.1",
         "chalk": "1.1.3",
-        "clone": "2.1.1",
+        "clone": "2.1.2",
         "cssbeautify": "0.3.1",
         "doctrine": "2.1.0",
         "dom5": "3.0.0",
         "indent": "0.0.2",
-        "jsonschema": "1.2.2",
+        "is-windows": "1.0.2",
+        "jsonschema": "1.2.4",
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
-        "polymer-project-config": "3.8.1",
+        "path-is-inside": "1.0.2",
+        "polymer-project-config": "3.13.0",
+        "resolve": "1.7.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
         "strip-indent": "2.0.0",
-        "vscode-uri": "1.0.1"
+        "vscode-uri": "1.0.3",
+        "whatwg-url": "6.4.0"
       },
       "dependencies": {
         "@types/doctrine": {
@@ -773,37 +1730,74 @@
           "dev": true
         },
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "polymer-project-config": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
-      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.13.0.tgz",
+      "integrity": "sha512-0E1iSOpo2xFMvMomSDFl48J8IOUWmM+sfHGJSQSVfIu8GXDgz2TVraad+rEMZDbj8uxiRFvQZyouHhikxhVFpQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
-        "jsonschema": "1.2.2",
+        "@types/node": "6.0.105",
+        "jsonschema": "1.2.4",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.101",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+          "version": "6.0.105",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.105.tgz",
+          "integrity": "sha512-fMIbw7iw91TSInS3b2DtDse5VaQEZqs0oTjvRNIFHnoHbnji+dLwpzL1L6dYGL39RzDNPHM/Off+VNcMk4ahwQ==",
           "dev": true
         }
       }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
       "dev": true
     },
     "reduce-flatten": {
@@ -818,6 +1812,28 @@
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -827,17 +1843,221 @@
         "is-finite": "1.0.2"
       }
     },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
     "shady-css-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "dev": true,
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
     },
     "stable": {
       "version": "0.1.6",
@@ -850,6 +2070,27 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -867,15 +2108,18 @@
       "dev": true
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
     },
     "table-layout": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.3.tgz",
+      "integrity": "sha512-MIhflPM38ejKrFwWwC3P9x3eHvMo5G5AmNo29Qtz2HpBl5KD2GCcmOErjgNtUQLv/qaqVDagfJY3rJLPDvEgLg==",
       "dev": true,
       "requires": {
         "array-back": "2.0.0",
@@ -901,6 +2145,57 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -922,22 +2217,141 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
       "dev": true
     },
-    "vscode-uri": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
-      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g=",
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "dev": true,
+      "requires": {
+        "kind-of": "6.0.2"
+      }
+    },
+    "vscode-uri": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI=",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "webmat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/webmat/-/webmat-0.2.0.tgz",
+      "integrity": "sha512-xf2iHrssbbTofFwxvrdtgSxILQ8ledlpeDc76fNkTEL76gGnxCB/YA69UF498+UPfYIDvVnk9Qt2E7MJOApacA==",
+      "dev": true,
+      "requires": {
+        "clang-format": "1.2.3",
+        "dom5": "3.0.0",
+        "fast-glob": "2.2.0",
+        "parse5": "4.0.0"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
+      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
       "dev": true,
       "requires": {
         "async": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@polymer/gen-typescript-declarations": "^1.2.0",
-    "bower": "^1.8.0"
+    "bower": "^1.8.0",
+    "webmat": "^0.2.0"
   },
   "scripts": {
-    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir ."
+    "update-types": "bower install && gen-typescript-declarations --deleteExisting --outDir .",
+    "format": "webmat && npm run update-types"
   }
 }

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -560,7 +560,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
 
         test('if `contentType` is json, the body is json encoded', function() {
-          var requestObj = {foo: 'bar', baz: [1, 2, 3]} ajax.body = requestObj;
+          var requestObj = {foo: 'bar', baz: [1, 2, 3]};
+          ajax.body = requestObj;
           ajax.contentType = 'application/json';
           ajax.generateRequest();
 

--- a/test/iron-ajax.html
+++ b/test/iron-ajax.html
@@ -79,8 +79,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'use strict';
     suite('<iron-ajax>', function() {
       var responseHeaders = {
-        json: { 'Content-Type': 'application/json' },
-        plain: { 'Content-Type': 'text/plain' }
+        json: {'Content-Type': 'application/json'},
+        plain: {'Content-Type': 'text/plain'}
       };
       var ajax;
       var request;
@@ -97,54 +97,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function() {
         server = sinon.fakeServer.create();
         server.respondWith(
-          'GET',
-          /\/responds_to_get_with_json.*/,
-          [
-            200,
-            responseHeaders.json,
-            '{"success":true}'
-          ]
-        );
+            'GET',
+            /\/responds_to_get_with_json.*/,
+            [200, responseHeaders.json, '{"success":true}']);
 
         server.respondWith(
-          'POST',
-          '/responds_to_post_with_json',
-          [
-            200,
-            responseHeaders.json,
-            '{"post_success":true}'
-          ]
-        );
+            'POST',
+            '/responds_to_post_with_json',
+            [200, responseHeaders.json, '{"post_success":true}']);
 
         server.respondWith(
-          'GET',
-          '/responds_to_get_with_text',
-          [
-            200,
-            responseHeaders.plain,
-            'Hello World'
-          ]
-        );
+            'GET',
+            '/responds_to_get_with_text',
+            [200, responseHeaders.plain, 'Hello World']);
 
         server.respondWith(
-          'GET',
-          '/responds_to_debounced_get_with_json',
-          [
-            200,
-            responseHeaders.json,
-            '{"success": "true"}'
-          ]
-        );
+            'GET',
+            '/responds_to_debounced_get_with_json',
+            [200, responseHeaders.json, '{"success": "true"}']);
 
         server.respondWith(
-          'GET',
-          '/responds_to_get_with_502_error_json',
-          [
-            502,
-            responseHeaders.json,
-            '{"message": "an error has occurred"}'
-          ]
-        );
+            'GET',
+            '/responds_to_get_with_502_error_json',
+            [502, responseHeaders.json, '{"message": "an error has occurred"}']);
 
         ajax = fixture('TrivialGet');
       });
@@ -161,9 +136,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // This way we can test for delayed and out of order responses and
       // distinquish them by their responses.
       function respondToEchoRequest(request) {
-        request.respond(200, responseHeaders.json, JSON.stringify({
-          url: request.url
-        }));
+        request.respond(
+            200, responseHeaders.json, JSON.stringify({url: request.url}));
       }
 
       suite('when making simple GET requests for JSON', function() {
@@ -189,8 +163,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           expect(options.headers).to.be.ok;
           expect(options.headers['custom-header']).to.be.an('string');
-          expect(options.headers.hasOwnProperty('custom-header')).to.be.equal(
-              true);
+          expect(options.headers.hasOwnProperty('custom-header')).to.be.equal(true);
         });
 
         test('non-objects in headers are not applied', function() {
@@ -206,22 +179,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(server.requests.length).to.be.equal(0);
           ajax = fixture('BlankUrl');
 
-          return timePasses(1).then(function() {
-            // We don't make any requests.
-            expect(server.requests.length).to.be.equal(0);
+          return timePasses(1)
+              .then(function() {
+                // We don't make any requests.
+                expect(server.requests.length).to.be.equal(0);
 
-            // Explicitly asking for the request to fire works.
-            ajax.generateRequest();
-            expect(server.requests.length).to.be.equal(1);
-            server.requests = [];
+                // Explicitly asking for the request to fire works.
+                ajax.generateRequest();
+                expect(server.requests.length).to.be.equal(1);
+                server.requests = [];
 
-            // Explicitly setting url to '' works too.
-            ajax = fixture('BlankUrl');
-            ajax.url = '';
-            return timePasses(1);
-          }).then(function() {
-            expect(server.requests.length).to.be.equal(1);
-          });
+                // Explicitly setting url to '' works too.
+                ajax = fixture('BlankUrl');
+                ajax.url = '';
+                return timePasses(1);
+              })
+              .then(function() {
+                expect(server.requests.length).to.be.equal(1);
+              });
         });
 
         test('requestUrl remains empty despite valid queryString', function() {
@@ -230,39 +205,43 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ajax.queryString).to.be.equal('');
           expect(ajax.requestUrl).to.be.equal('');
 
-          ajax.params = {'a':'b', 'c':'d'};
+          ajax.params = {'a': 'b', 'c': 'd'};
 
           expect(ajax.queryString).to.be.equal('a=b&c=d');
           expect(ajax.requestUrl).to.be.equal('?a=b&c=d');
         });
 
-        test('generateRequest works with empty URL and valid queryString', function() {
-          ajax = fixture('BlankUrl');
-          expect(ajax.url).to.be.equal(undefined);
+        test(
+            'generateRequest works with empty URL and valid queryString',
+            function() {
+              ajax = fixture('BlankUrl');
+              expect(ajax.url).to.be.equal(undefined);
 
-          ajax.generateRequest();
-          expect(server.requests[0].url).to.be.eql('');
+              ajax.generateRequest();
+              expect(server.requests[0].url).to.be.eql('');
 
-          ajax.params = {'a':'b', 'c':'d'};
+              ajax.params = {'a': 'b', 'c': 'd'};
 
-          ajax.generateRequest();
-          expect(server.requests[1].url).to.be.eql('?a=b&c=d');
-        });
+              ajax.generateRequest();
+              expect(server.requests[1].url).to.be.eql('?a=b&c=d');
+            });
       });
 
       suite('when properties are changed', function() {
-        test('generates simple-request elements that reflect the change', function() {
-          request = ajax.generateRequest();
+        test(
+            'generates simple-request elements that reflect the change',
+            function() {
+              request = ajax.generateRequest();
 
-          expect(request.xhr.method).to.be.equal('GET');
+              expect(request.xhr.method).to.be.equal('GET');
 
-          ajax.method = 'POST';
-          ajax.url = '/responds_to_post_with_json';
+              ajax.method = 'POST';
+              ajax.url = '/responds_to_post_with_json';
 
-          request = ajax.generateRequest();
+              request = ajax.generateRequest();
 
-          expect(request.xhr.method).to.be.equal('POST');
-        });
+              expect(request.xhr.method).to.be.equal('POST');
+            });
       });
 
       suite('when generating a request', function() {
@@ -286,7 +265,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('encodes array params properly', function() {
-          ajax.params = {'a b': ['c','d e', 'f']};
+          ajax.params = {'a b': ['c', 'd e', 'f']};
 
           expect(ajax.queryString).to.be.equal('a%20b=c&a%20b=d%20e&a%20b=f');
         });
@@ -298,11 +277,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           server.respond();
 
-          return request.completes.then(function() {
-            return timePasses(1);
-          }).then(function() {
-            expect(ajax.loading).to.be.equal(false);
-          });
+          return request.completes
+              .then(function() {
+                return timePasses(1);
+              })
+              .then(function() {
+                expect(ajax.loading).to.be.equal(false);
+              });
         });
 
         test('the `iron-ajax-presend` event gets fired', function() {
@@ -331,11 +312,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           server.respond();
 
-          return request.completes.then(function() {
-            return timePasses(1);
-          }).then(function() {
-            expect(count).to.be.equal(2);
-          });
+          return request.completes
+              .then(function() {
+                return timePasses(1);
+              })
+              .then(function() {
+                expect(count).to.be.equal(2);
+              });
         });
       });
 
@@ -352,7 +335,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             echoAjax.params = {'order': i + 1};
             requests.push(echoAjax.generateRequest());
           }
-          var allPromises = requests.map(function(r){return r.completes});
+          var allPromises = requests.map(function(r) {
+            return r.completes
+          });
           promiseAllComplete = Promise.all(allPromises);
         });
 
@@ -365,11 +350,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           for (var i = 0; i < 3; i++) {
             respondToEchoRequest(server.requests[i]);
           }
-          return promiseAllComplete.then(function() {
-            return timePasses(1);
-          }).then(function() {
-            expect(echoAjax.activeRequests.length).to.be.equal(0);
-          });
+          return promiseAllComplete
+              .then(function() {
+                return timePasses(1);
+              })
+              .then(function() {
+                expect(echoAjax.activeRequests.length).to.be.equal(0);
+              });
         });
 
         test('avoids race conditions with last response', function() {
@@ -377,48 +364,58 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           // Resolving the oldest request doesn't update lastResponse.
           respondToEchoRequest(server.requests[0]);
-          return requests[0].completes.then(function() {
-            expect(echoAjax.lastResponse).to.be.equal(undefined);
+          return requests[0]
+              .completes
+              .then(function() {
+                expect(echoAjax.lastResponse).to.be.equal(undefined);
 
-            // Resolving the most recent request does!
-            respondToEchoRequest(server.requests[2]);
-            return requests[2].completes;
-          }).then(function() {
-            expect(echoAjax.lastResponse).to.be.deep.eql(
-                {url: '/echoes_request_url?order=3'});
+                // Resolving the most recent request does!
+                respondToEchoRequest(server.requests[2]);
+                return requests[2].completes;
+              })
+              .then(function() {
+                expect(echoAjax.lastResponse).to.be.deep.eql({
+                  url: '/echoes_request_url?order=3'
+                });
 
 
-            // Resolving an out of order stale request after does nothing!
-            respondToEchoRequest(server.requests[1]);
-            return requests[1].completes;
-          }).then(function() {
-            expect(echoAjax.lastResponse).to.be.deep.eql(
-                {url: '/echoes_request_url?order=3'});
-          });
+                // Resolving an out of order stale request after does nothing!
+                respondToEchoRequest(server.requests[1]);
+                return requests[1].completes;
+              })
+              .then(function() {
+                expect(echoAjax.lastResponse).to.be.deep.eql({
+                  url: '/echoes_request_url?order=3'
+                });
+              });
         });
 
         test('`loading` is true while the last one is loading', function() {
           expect(echoAjax.loading).to.be.equal(true);
 
           respondToEchoRequest(server.requests[0]);
-          return requests[0].completes.then(function() {
-            // We're still loading because requests[2] is the most recently
-            // made request.
-            expect(echoAjax.loading).to.be.equal(true);
+          return requests[0]
+              .completes
+              .then(function() {
+                // We're still loading because requests[2] is the most recently
+                // made request.
+                expect(echoAjax.loading).to.be.equal(true);
 
-            respondToEchoRequest(server.requests[2]);
-            return requests[2].completes;
-          }).then(function() {
-            // Now we're done loading.
-            expect(echoAjax.loading).to.be.eql(false);
+                respondToEchoRequest(server.requests[2]);
+                return requests[2].completes;
+              })
+              .then(function() {
+                // Now we're done loading.
+                expect(echoAjax.loading).to.be.eql(false);
 
-            // Resolving an out of order stale request after should have
-            // no effect.
-            respondToEchoRequest(server.requests[1]);
-            return requests[1].completes;
-          }).then(function() {
-            expect(echoAjax.loading).to.be.eql(false);
-          });
+                // Resolving an out of order stale request after should have
+                // no effect.
+                respondToEchoRequest(server.requests[1]);
+                return requests[1].completes;
+              })
+              .then(function() {
+                expect(echoAjax.loading).to.be.eql(false);
+              });
         });
       });
 
@@ -480,25 +477,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             });
 
             ajax.handleas = 'text';
-            ajax.params = { foo: 'bar' };
-            ajax.headers = { 'X-Foo': 'Bar' };
+            ajax.params = {foo: 'bar'};
+            ajax.headers = {'X-Foo': 'Bar'};
           });
         });
 
-        test('automatically generates new request when a sub-property of params is changed', function(done) {
-          ajax.addEventListener('request', function() {
-            server.respond();
-          });
+        test(
+            'automatically generates new request when a sub-property of params is changed',
+            function(done) {
+              ajax.addEventListener('request', function() {
+                server.respond();
+              });
 
-          ajax.params = { foo: 'bar' };
-          ajax.addEventListener('response', function() {
-            ajax.addEventListener('request', function() {
-              done();
+              ajax.params = {foo: 'bar'};
+              ajax.addEventListener('response', function() {
+                ajax.addEventListener('request', function() {
+                  done();
+                });
+
+                ajax.set('params.foo', 'xyz');
+              });
             });
-
-            ajax.set('params.foo', 'xyz');
-          });
-        });
       });
 
       suite('the last response', function() {
@@ -515,20 +514,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
         test('updates with each new response', function() {
-          return request.completes.then(function(request) {
+          return request.completes
+              .then(function(request) {
+                expect(request.response).to.be.an('object');
+                expect(ajax.lastResponse).to.be.equal(request.response);
 
-            expect(request.response).to.be.an('object');
-            expect(ajax.lastResponse).to.be.equal(request.response);
+                ajax.handleAs = 'text';
+                request = ajax.generateRequest();
+                server.respond();
 
-            ajax.handleAs = 'text';
-            request = ajax.generateRequest();
-            server.respond();
-
-            return request.completes;
-          }).then(function(request) {
-            expect(request.response).to.be.a('string');
-            expect(ajax.lastResponse).to.be.equal(request.response);
-          });
+                return request.completes;
+              })
+              .then(function(request) {
+                expect(request.response).to.be.a('string');
+                expect(ajax.lastResponse).to.be.equal(request.response);
+              });
         });
       });
 
@@ -547,25 +547,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(server.requests[0].requestBody).to.be.equal(requestBody);
         });
 
-        test('if `contentType` is set to form encode, the body is encoded',function() {
-          ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
-          ajax.contentType = 'application/x-www-form-urlencoded';
-          ajax.generateRequest();
+        test(
+            'if `contentType` is set to form encode, the body is encoded',
+            function() {
+              ajax.body = {foo: 'bar\nbip', 'biz bo': 'baz blar'};
+              ajax.contentType = 'application/x-www-form-urlencoded';
+              ajax.generateRequest();
 
-          expect(server.requests[0]).to.be.ok;
-          expect(server.requests[0].requestBody).to.be.equal(
-              'foo=bar%0D%0Abip&biz+bo=baz+blar');
-        });
+              expect(server.requests[0]).to.be.ok;
+              expect(server.requests[0].requestBody)
+                  .to.be.equal('foo=bar%0D%0Abip&biz+bo=baz+blar');
+            });
 
         test('if `contentType` is json, the body is json encoded', function() {
-          var requestObj = {foo: 'bar', baz: [1,2,3]}
-          ajax.body = requestObj;
+          var requestObj = {foo: 'bar', baz: [1, 2, 3]} ajax.body = requestObj;
           ajax.contentType = 'application/json';
           ajax.generateRequest();
 
           expect(server.requests[0]).to.be.ok;
-          expect(server.requests[0].requestBody).to.be.equal(
-              JSON.stringify(requestObj));
+          expect(server.requests[0].requestBody)
+              .to.be.equal(JSON.stringify(requestObj));
         });
 
         suite('the examples in the documentation work', function() {
@@ -575,8 +576,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ajax.generateRequest();
 
             expect(server.requests[0]).to.be.ok;
-            expect(server.requests[0].requestBody).to.be.equal(
-                '{"foo":"bar baz","x":1}');
+            expect(server.requests[0].requestBody)
+                .to.be.equal('{"foo":"bar baz","x":1}');
           });
 
           test('form content, body attribute is an object', function() {
@@ -585,14 +586,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ajax.generateRequest();
 
             expect(server.requests[0]).to.be.ok;
-            expect(server.requests[0].requestBody).to.be.equal(
-                'foo=bar+baz&x=1');
+            expect(server.requests[0].requestBody).to.be.equal('foo=bar+baz&x=1');
           });
         });
 
         suite('and `contentType` is explicitly set to form encode', function() {
           test('we encode a custom object', function() {
-            function Foo(bar) { this.bar = bar };
+            function Foo(bar) {
+              this.bar = bar
+            };
             var requestObj = new Foo('baz');
             ajax.body = requestObj;
             ajax.contentType = 'application/x-www-form-urlencoded';
@@ -667,24 +669,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       suite('when handleAs parameter is `text`', function() {
-
         test('response type is string', function() {
           ajax.url = '/responds_to_get_with_json';
           ajax.handleAs = 'text';
 
           request = ajax.generateRequest();
           var promise = request.completes.then(function() {
-            expect(typeof(ajax.lastResponse)).to.be.equal('string');
+            expect(typeof (ajax.lastResponse)).to.be.equal('string');
           });
 
           expect(server.requests.length).to.be.equal(1);
-          expect(server.requests[0].requestHeaders['accept']).to.be.equal(
-            'text/plain');
+          expect(server.requests[0].requestHeaders['accept'])
+              .to.be.equal('text/plain');
           server.respond();
 
           return promise;
         });
-
       });
 
       suite('when a request fails', function() {
@@ -698,90 +698,104 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             eventFired = true;
           });
           var request = ajax.generateRequest();
-          var promise = request.completes.then(function() {
-            throw new Error('Expected the request to fail!');
-          }, function(error) {
-            expect(error).to.be.instanceof(Error);
-            expect(request.succeeded).to.be.eq(false);
-            return timePasses(100);
-          }).then(function() {
-            expect(eventFired).to.be.eq(true);
-            expect(ajax.lastError).to.not.be.eq(null);
-            expect(ajax.lastError.status).to.be.eq(502);
-            expect(ajax.lastError.statusText).to.be.eq("Bad Gateway");
-            expect(ajax.lastError.response).to.be.ok;
-          });
+          var promise =
+              request.completes
+                  .then(
+                      function() {
+                        throw new Error('Expected the request to fail!');
+                      },
+                      function(error) {
+                        expect(error).to.be.instanceof(Error);
+                        expect(request.succeeded).to.be.eq(false);
+                        return timePasses(100);
+                      })
+                  .then(function() {
+                    expect(eventFired).to.be.eq(true);
+                    expect(ajax.lastError).to.not.be.eq(null);
+                    expect(ajax.lastError.status).to.be.eq(502);
+                    expect(ajax.lastError.statusText).to.be.eq('Bad Gateway');
+                    expect(ajax.lastError.response).to.be.ok;
+                  });
 
           server.respond();
 
           return promise;
         });
 
-        test('with rejectWithRequest the promise chain contains the request and error', function() {
-          ajax.url = '/responds_to_get_with_502_error_json';
-          ajax.handleAs = 'json';
-          ajax.rejectWithRequest = true;
+        test(
+            'with rejectWithRequest the promise chain contains the request and error',
+            function() {
+              ajax.url = '/responds_to_get_with_502_error_json';
+              ajax.handleAs = 'json';
+              ajax.rejectWithRequest = true;
 
-          var request = ajax.generateRequest();
-          var promise = request.completes.then(function() {
-            throw new Error('Expected the request to fail!');
-          }, function(resp) {
-            expect(resp.error).to.be.instanceof(Error);
-            expect(resp.request).to.deep.equal(request);
-          });
+              var request = ajax.generateRequest();
+              var promise = request.completes.then(
+                  function() {
+                    throw new Error('Expected the request to fail!');
+                  },
+                  function(resp) {
+                    expect(resp.error).to.be.instanceof(Error);
+                    expect(resp.request).to.deep.equal(request);
+                  });
 
-          server.respond();
+              server.respond();
 
-          return promise;
-        });
+              return promise;
+            });
 
-        test('we give a useful error even when the domain doesn\'t resolve', function() {
-          ajax.url = 'http://nonexistant.example.com/';
-          server.restore();
-          var eventFired = false;
-          ajax.addEventListener('error', function(event) {
-            expect(event.detail.request).to.be.ok;
-            expect(event.detail.error).to.be.ok;
-            eventFired = true;
-          });
-          var request = ajax.generateRequest();
-          var promise = request.completes.then(function() {
-            throw new Error('Expected the request to fail!');
-          }, function(error) {
-            expect(request.succeeded).to.be.eq(false);
-            expect(error).to.not.be.eq(null);
-            return timePasses(100);
-          }).then(function() {
-            expect(eventFired).to.be.eq(true);
-            expect(ajax.lastError).to.not.be.eq(null);
-          });
+        test(
+            'we give a useful error even when the domain doesn\'t resolve',
+            function() {
+              ajax.url = 'http://nonexistant.example.com/';
+              server.restore();
+              var eventFired = false;
+              ajax.addEventListener('error', function(event) {
+                expect(event.detail.request).to.be.ok;
+                expect(event.detail.error).to.be.ok;
+                eventFired = true;
+              });
+              var request = ajax.generateRequest();
+              var promise =
+                  request.completes
+                      .then(
+                          function() {
+                            throw new Error('Expected the request to fail!');
+                          },
+                          function(error) {
+                            expect(request.succeeded).to.be.eq(false);
+                            expect(error).to.not.be.eq(null);
+                            return timePasses(100);
+                          })
+                      .then(function() {
+                        expect(eventFired).to.be.eq(true);
+                        expect(ajax.lastError).to.not.be.eq(null);
+                      });
 
-          server.respond();
+              server.respond();
 
-          return promise;
-        });
+              return promise;
+            });
       });
 
       suite('when handleAs parameter is `json`', function() {
-
         test('response type is string', function() {
           ajax.url = '/responds_to_get_with_json';
           ajax.handleAs = 'json';
 
           request = ajax.generateRequest();
           var promise = request.completes.then(function() {
-            expect(typeof(ajax.lastResponse)).to.be.equal('object');
+            expect(typeof (ajax.lastResponse)).to.be.equal('object');
           });
 
           expect(server.requests.length).to.be.equal(1);
-          expect(server.requests[0].requestHeaders['accept']).to.be.equal(
-            'application/json');
+          expect(server.requests[0].requestHeaders['accept'])
+              .to.be.equal('application/json');
 
           server.respond();
 
           return promise;
         });
-
       });
 
       suite('when making a POST over the wire', function() {
@@ -794,8 +808,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var ajax = fixture('RealPost');
           ajax.body = requestBody;
           return ajax.generateRequest().completes.then(function() {
-            expect(ajax.lastResponse.headers['Content-Type']).to.match(
-                /^multipart\/form-data; boundary=.*$/);
+            expect(ajax.lastResponse.headers['Content-Type'])
+                .to.match(/^multipart\/form-data; boundary=.*$/);
 
             expect(ajax.lastResponse.form.a).to.be.equal('foo');
             expect(ajax.lastResponse.form.b).to.be.equal('bar');
@@ -808,8 +822,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ajax.body = JSON.stringify({a: 'foo', b: 'bar'});
           ajax.contentType = 'application/json';
           return ajax.generateRequest().completes.then(function() {
-            expect(ajax.lastResponse.headers['Content-Type']).to.match(
-                /^application\/json(;.*)?$/);
+            expect(ajax.lastResponse.headers['Content-Type'])
+                .to.match(/^application\/json(;.*)?$/);
             expect(ajax.lastResponse.json.a).to.be.equal('foo');
             expect(ajax.lastResponse.json.b).to.be.equal('bar');
           });
@@ -820,8 +834,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var ajax = fixture('RealPost');
           ajax.body = 'a=foo&b=bar';
           return ajax.generateRequest().completes.then(function() {
-            expect(ajax.lastResponse.headers['Content-Type']).to.match(
-                /^application\/x-www-form-urlencoded(;.*)?$/);
+            expect(ajax.lastResponse.headers['Content-Type'])
+                .to.match(/^application\/x-www-form-urlencoded(;.*)?$/);
 
             expect(ajax.lastResponse.form.a).to.be.equal('foo');
             expect(ajax.lastResponse.form.b).to.be.equal('bar');
@@ -832,17 +846,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           server.restore();
           var ajax = fixture('RealPost');
 
-          var xmlDoc = document.implementation.createDocument(
-              null, "foo", null);
-          var node = xmlDoc.createElement("bar");
-          node.setAttribute("name" , "baz");
+          var xmlDoc = document.implementation.createDocument(null, 'foo', null);
+          var node = xmlDoc.createElement('bar');
+          node.setAttribute('name', 'baz');
           xmlDoc.documentElement.appendChild(node);
           ajax.body = xmlDoc;
           return ajax.generateRequest().completes.then(function() {
-            expect(ajax.lastResponse.headers['Content-Type']).to.match(
-                /^application\/xml(;.*)?$/);
-            expect(ajax.lastResponse.data).to.match(
-                /<foo\s*><bar\s+name="baz"\s*\/><\/foo\s*>/);
+            expect(ajax.lastResponse.headers['Content-Type'])
+                .to.match(/^application\/xml(;.*)?$/);
+            expect(ajax.lastResponse.data)
+                .to.match(/<foo\s*><bar\s+name="baz"\s*\/><\/foo\s*>/);
           });
         });
       });
@@ -854,72 +867,79 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         test('it is present in the request xhr object', function() {
           ajax.url = '/responds_to_get_with_json';
-          ajax.timeout = 5000; // 5 Seconds
+          ajax.timeout = 5000;  // 5 Seconds
 
           request = ajax.generateRequest();
-          expect(request.xhr.timeout).to.be.equal(5000); // 5 Seconds
+          expect(request.xhr.timeout).to.be.equal(5000);  // 5 Seconds
         });
 
         test('it fails once that timeout is reached', function() {
           var ajax = fixture('Delay');
-          ajax.timeout = 1; // 1 Millisecond
+          ajax.timeout = 1;  // 1 Millisecond
 
           request = ajax.generateRequest();
-          return request.completes.then(function() {
-            throw new Error('Expected the request to throw an error.');
-          }, function() {
-            expect(request.succeeded).to.be.equal(false);
-            expect(request.xhr.status).to.be.equal(0);
-            expect(request.timedOut).to.be.equal(true);
-            return timePasses(1);
-          }).then(function() {
-            expect(ajax.loading).to.be.equal(false);
-            expect(ajax.lastResponse).to.be.equal(null);
-            expect(ajax.lastError).to.not.be.equal(null);
-          });
+          return request.completes
+              .then(
+                  function() {
+                    throw new Error('Expected the request to throw an error.');
+                  },
+                  function() {
+                    expect(request.succeeded).to.be.equal(false);
+                    expect(request.xhr.status).to.be.equal(0);
+                    expect(request.timedOut).to.be.equal(true);
+                    return timePasses(1);
+                  })
+              .then(function() {
+                expect(ajax.loading).to.be.equal(false);
+                expect(ajax.lastResponse).to.be.equal(null);
+                expect(ajax.lastError).to.not.be.equal(null);
+              });
         });
       });
 
       suite('when using the bubbles attribute', function() {
-        test('the request and response events should bubble to window', function(done) {
-          server.restore();
-          var total = 0;
-          function incrementTotal() {
-            total++;
-            if (total === 5) {
-              done();
-            }
-          }
-          window.addEventListener('iron-ajax-presend', incrementTotal);
-          window.addEventListener('request', incrementTotal);
-          window.addEventListener('iron-ajax-request', incrementTotal);
-          window.addEventListener('response', incrementTotal);
-          window.addEventListener('iron-ajax-response', incrementTotal);
-          var ajax = fixture('Bubbles')[0];
-          ajax.generateRequest();
-          server.respond();
-        });
+        test(
+            'the request and response events should bubble to window',
+            function(done) {
+              server.restore();
+              var total = 0;
+              function incrementTotal() {
+                total++;
+                if (total === 5) {
+                  done();
+                }
+              }
+              window.addEventListener('iron-ajax-presend', incrementTotal);
+              window.addEventListener('request', incrementTotal);
+              window.addEventListener('iron-ajax-request', incrementTotal);
+              window.addEventListener('response', incrementTotal);
+              window.addEventListener('iron-ajax-response', incrementTotal);
+              var ajax = fixture('Bubbles')[0];
+              ajax.generateRequest();
+              server.respond();
+            });
 
-        test('the request and error events should bubble to window', function(done) {
-          var total = 0;
-          function incrementTotal() {
-            total++;
-            if (total === 5) {
-              done();
-            }
-          }
-          window.addEventListener('iron-ajax-presend', incrementTotal);
-          window.addEventListener('request', incrementTotal);
-          window.addEventListener('iron-ajax-request', incrementTotal);
-          // NOTE(cdata): This needs to be capturing because Mocha + Firefox
-          // results in the error event being observed too early by the test
-          // runner and failing the test:
-          window.addEventListener('error', incrementTotal, true);
-          window.addEventListener('iron-ajax-error', incrementTotal);
-          var ajax = fixture('Bubbles')[1];
-          ajax.generateRequest();
-          server.respond();
-        });
+        test(
+            'the request and error events should bubble to window', function(done) {
+              var total = 0;
+              function incrementTotal() {
+                total++;
+                if (total === 5) {
+                  done();
+                }
+              }
+              window.addEventListener('iron-ajax-presend', incrementTotal);
+              window.addEventListener('request', incrementTotal);
+              window.addEventListener('iron-ajax-request', incrementTotal);
+              // NOTE(cdata): This needs to be capturing because Mocha + Firefox
+              // results in the error event being observed too early by the test
+              // runner and failing the test:
+              window.addEventListener('error', incrementTotal, true);
+              window.addEventListener('iron-ajax-error', incrementTotal);
+              var ajax = fixture('Bubbles')[1];
+              ajax.generateRequest();
+              server.respond();
+            });
       });
 
       suite('when handling the `iron-ajax-presend` event', function() {
@@ -938,13 +958,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           var request = ajax.generateRequest();
 
-          return request.completes.catch(function(request) {
-            expect(request.aborted).to.be.true;
-            promiseSpy();
-          }).then(function() {
-            expect(promiseSpy).to.be.calledOnce;
-            expect(requestSpy).not.to.be.called;
-          });
+          return request.completes
+              .catch(function(request) {
+                expect(request.aborted).to.be.true;
+                promiseSpy();
+              })
+              .then(function() {
+                expect(promiseSpy).to.be.calledOnce;
+                expect(requestSpy).not.to.be.called;
+              });
         });
 
         test('ability to modify the request options', function(done) {
@@ -953,7 +975,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             e.detail.options.headers.authToken = 'a.b.c';
           });
           ajax.addEventListener('iron-ajax-request', function(e) {
-            expect(e.detail.options.url).to.equal('/responds_to_get_with_json/test');
+            expect(e.detail.options.url)
+                .to.equal('/responds_to_get_with_json/test');
             expect(e.detail.options.headers.authToken).to.equal('a.b.c');
             done();
           });
@@ -986,24 +1009,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             lastProgressUpdated = true;
           };
 
-          ajax.lastRequest.completes.then(function() {
-            // should have something from last request
-            expect(ajax.lastProgress).to.be.ok;
-            ajax.removeEventListener('last-progress-changed',
-                onLastProgressChanged);
-            ajax.generateRequest();
+          ajax.lastRequest.completes
+              .then(function() {
+                // should have something from last request
+                expect(ajax.lastProgress).to.be.ok;
+                ajax.removeEventListener(
+                    'last-progress-changed', onLastProgressChanged);
+                ajax.generateRequest();
 
-            // should reset
-            expect(ajax.lastProgress).to.be.eql(null);
+                // should reset
+                expect(ajax.lastProgress).to.be.eql(null);
 
-            if (lastProgressUpdated) {
-              done();
-            } else {
-              done('lastProgress was never updated');
-            }
-          }).catch(function(err) {
-            done(err);
-          });
+                if (lastProgressUpdated) {
+                  done();
+                } else {
+                  done('lastProgress was never updated');
+                }
+              })
+              .catch(function(err) {
+                done(err);
+              });
 
           server.respond();
 

--- a/test/iron-request.html
+++ b/test/iron-request.html
@@ -37,45 +37,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var server;
 
       setup(function() {
-        jsonResponseHeaders = {
-          'Content-Type': 'application/json'
-        };
+        jsonResponseHeaders = {'Content-Type': 'application/json'};
         server = sinon.fakeServer.create();
-        server.respondWith('GET', '/responds_to_get_with_json', [
-          200,
-          jsonResponseHeaders,
-          '{"success":true}'
-        ]);
+        server.respondWith(
+            'GET',
+            '/responds_to_get_with_json',
+            [200, jsonResponseHeaders, '{"success":true}']);
 
-        server.respondWith('GET', '/responds_to_get_with_prefixed_json', [
-          200,
-          jsonResponseHeaders,
-          '])}while(1);</x>{"success":true}'
-        ]);
+        server.respondWith(
+            'GET',
+            '/responds_to_get_with_prefixed_json',
+            [200, jsonResponseHeaders, '])}while(1);</x>{"success":true}']);
 
-        server.respondWith('GET', '/responds_to_get_with_500', [
-          500,
-          {},
-          ''
-        ]);
+        server.respondWith('GET', '/responds_to_get_with_500', [500, {}, '']);
 
-        server.respondWith('GET', '/responds_to_get_with_100', [
-          100,
-          {},
-          ''
-        ]);
+        server.respondWith('GET', '/responds_to_get_with_100', [100, {}, '']);
 
-        server.respondWith('GET', '/responds_to_get_with_0', [
-          0,
-          jsonResponseHeaders,
-          '{"success":true}'
-        ]);
+        server.respondWith(
+            'GET',
+            '/responds_to_get_with_0',
+            [0, jsonResponseHeaders, '{"success":true}']);
 
 
         request = fixture('TrivialRequest');
-        successfulRequestOptions = {
-          url: '/responds_to_get_with_json'
-        };
+        successfulRequestOptions = {url: '/responds_to_get_with_json'};
 
         synchronousSuccessfulRequestOptions = {
           url: '/responds_to_get_with_json',
@@ -135,11 +120,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           server.respond();
 
-          return request.completes.then(function() {
-            throw new Error('Request did not abort appropriately!');
-          }).catch(function(e) {
-            expect(request.response).to.not.be.ok;
-          });
+          return request.completes
+              .then(function() {
+                throw new Error('Request did not abort appropriately!');
+              })
+              .catch(function(e) {
+                expect(request.response).to.not.be.ok;
+              });
         });
 
         test('can be aborted with request element', function() {
@@ -153,12 +140,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           server.respond();
 
-          return request.completes.then(function() {
-            throw new Error('Request did not abort appropriately!');
-          }).catch(function(e) {
-            expect(e.error).to.be.instanceof(Error);
-            expect(e.request).to.deep.equal(request);
-          });
+          return request.completes
+              .then(function() {
+                throw new Error('Request did not abort appropriately!');
+              })
+              .catch(function(e) {
+                expect(e.error).to.be.instanceof(Error);
+                expect(e.request).to.deep.equal(request);
+              });
         });
 
         test('default responseType is text', function() {
@@ -170,17 +159,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('default responseType of text is not applied, when async is false', function() {
-          var options = Object.create(successfulRequestOptions);
-          options.async = false;
+        test(
+            'default responseType of text is not applied, when async is false',
+            function() {
+              var options = Object.create(successfulRequestOptions);
+              options.async = false;
 
-          request.send(options);
-          server.respond();
+              request.send(options);
+              server.respond();
 
-          return request.completes.then(function() {
-            expect(request.xhr.responseType).to.be.empty;
-          });
-        });
+              return request.completes.then(function() {
+                expect(request.xhr.responseType).to.be.empty;
+              });
+            });
 
         test('responseType can be configured via handleAs option', function() {
           var options = Object.create(successfulRequestOptions);
@@ -188,8 +179,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           request.send(options);
           expect(server.requests.length).to.be.equal(1);
-          expect(server.requests[0].requestHeaders['accept']).to.be.equal(
-              'application/json');
+          expect(server.requests[0].requestHeaders['accept'])
+              .to.be.equal('application/json');
           server.respond();
 
           return request.completes.then(function() {
@@ -197,39 +188,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
 
-        test('setting jsonPrefix correctly strips it from the response', function() {
-          var options = {
-            url: '/responds_to_get_with_prefixed_json',
-            handleAs: 'json',
-            jsonPrefix: '])}while(1);</x>'
-          };
+        test(
+            'setting jsonPrefix correctly strips it from the response', function() {
+              var options = {
+                url: '/responds_to_get_with_prefixed_json',
+                handleAs: 'json',
+                jsonPrefix: '])}while(1);</x>'
+              };
 
-          request.send(options);
-          expect(server.requests.length).to.be.equal(1);
-          expect(server.requests[0].requestHeaders['accept']).to.be.equal(
-              'application/json');
-          server.respond();
+              request.send(options);
+              expect(server.requests.length).to.be.equal(1);
+              expect(server.requests[0].requestHeaders['accept'])
+                  .to.be.equal('application/json');
+              server.respond();
 
-          return request.completes.then(function() {
-            expect(request.response).to.deep.eq({success: true});
-          });
-        });
+              return request.completes.then(function() {
+                expect(request.response).to.deep.eq({success: true});
+              });
+            });
 
-        test('responseType cannot be configured via handleAs option, when async is false', function() {
-          var options = Object.create(successfulRequestOptions);
-          options.handleAs = 'json';
-          options.async = false;
+        test(
+            'responseType cannot be configured via handleAs option, when async is false',
+            function() {
+              var options = Object.create(successfulRequestOptions);
+              options.handleAs = 'json';
+              options.async = false;
 
-          request.send(options);
-          expect(server.requests.length).to.be.equal(1);
-          expect(server.requests[0].requestHeaders['accept']).to.be.equal(
-              'application/json');
-          server.respond();
+              request.send(options);
+              expect(server.requests.length).to.be.equal(1);
+              expect(server.requests[0].requestHeaders['accept'])
+                  .to.be.equal('application/json');
+              server.respond();
 
-          return request.completes.then(function() {
-            expect(request.response).to.be.a('string');
-          });
-        });
+              return request.completes.then(function() {
+                expect(request.response).to.be.a('string');
+              });
+            });
 
         test('headers are sent up', function() {
           var options = Object.create(successfulRequestOptions);
@@ -240,10 +234,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           request.send(options);
           expect(server.requests.length).to.be.equal(1);
           var fakeXhr = server.requests[0]
-          expect(fakeXhr.requestHeaders['foo']).to.be.equal(
-              'bar');
-          expect(fakeXhr.requestHeaders['accept']).to.be.equal(
-              'this should override the default');
+          expect(fakeXhr.requestHeaders['foo']).to.be.equal('bar');
+          expect(fakeXhr.requestHeaders['accept'])
+              .to.be.equal('this should override the default');
         });
 
         test('headers are deduped by lowercasing', function() {
@@ -258,51 +251,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(server.requests.length).to.be.equal(1);
           var fakeXhr = server.requests[0]
           expect(Object.keys(fakeXhr.requestHeaders).length).to.be.equal(2);
-          expect(fakeXhr.requestHeaders['foo']).to.be.equal(
-              'bar');
-          expect(fakeXhr.requestHeaders['accept']).to.be.equal(
-              'this should also override the default');
+          expect(fakeXhr.requestHeaders['foo']).to.be.equal('bar');
+          expect(fakeXhr.requestHeaders['accept'])
+              .to.be.equal('this should also override the default');
         });
       });
 
       suite('special cases', function() {
-        test('treats status code 0 as success, though the outcome is ambiguous', function() {
-          // Note: file:// status code will probably be 0 no matter what happened.
-          request.send({
-            url: '/responds_to_get_with_0'
-          });
+        test(
+            'treats status code 0 as success, though the outcome is ambiguous',
+            function() {
+              // Note: file:// status code will probably be 0 no matter what
+              // happened.
+              request.send({url: '/responds_to_get_with_0'});
 
-          server.respond();
+              server.respond();
 
-          expect(request.succeeded).to.be.equal(true);
-        });
+              expect(request.succeeded).to.be.equal(true);
+            });
 
         test('special form characters', function() {
           var testCases = [
-            {
-              test: null,
-              answer: ''
-            },
-            {
-              test: undefined,
-              answer: ''
-            },
-            {
-              test: NaN,
-              answer: 'NaN'
-            },
+            {test: null, answer: ''},
+            {test: undefined, answer: ''},
+            {test: NaN, answer: 'NaN'},
             {
               test: new String('\n\r\n\r'),
-              answer: '%0D%0A%0D%0A%0D' // \r\n\r\n\r
+              answer: '%0D%0A%0D%0A%0D'  // \r\n\r\n\r
             },
-            {
-              test: 0,
-              answer: '0'
-            },
-            {
-              test: new String('hello world'),
-              answer: 'hello+world'
-            }
+            {test: 0, answer: '0'},
+            {test: new String('hello world'), answer: 'hello+world'}
           ];
 
           var testCase;
@@ -317,9 +295,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('errors', function() {
         test('treats status codes between 1 and 199 as errors', function() {
-          request.send({
-            url: '/responds_to_get_with_100'
-          });
+          request.send({url: '/responds_to_get_with_100'});
 
           server.respond();
 
@@ -327,9 +303,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('treats status codes between 300 and ∞ as errors', function() {
-          request.send({
-            url: '/responds_to_get_with_500'
-          });
+          request.send({url: '/responds_to_get_with_500'});
 
           server.respond();
 
@@ -339,9 +313,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       suite('status codes', function() {
         test('status and statusText is set after a ambiguous request', function() {
-          request.send({
-            url: '/responds_to_get_with_0'
-          });
+          request.send({url: '/responds_to_get_with_0'});
 
           server.respond();
 
@@ -349,27 +321,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(request.statusText).to.be.equal('');
         });
 
-        test('status and statusText is set after a request that succeeded', function() {
-          request.send({
-            url: '/responds_to_get_with_json'
-          });
+        test(
+            'status and statusText is set after a request that succeeded',
+            function() {
+              request.send({url: '/responds_to_get_with_json'});
 
-          server.respond();
+              server.respond();
 
-          expect(request.status).to.be.equal(200);
-          expect(request.statusText).to.be.equal('OK');
-        });
+              expect(request.status).to.be.equal(200);
+              expect(request.statusText).to.be.equal('OK');
+            });
 
-        test('status and statusText is set after a request that failed', function() {
-          request.send({
-            url: '/responds_to_get_with_500'
-          });
+        test(
+            'status and statusText is set after a request that failed', function() {
+              request.send({url: '/responds_to_get_with_500'});
 
-          server.respond();
+              server.respond();
 
-          expect(request.status).to.be.equal(500);
-          expect(request.statusText).to.be.equal('Internal Server Error');
-        });
+              expect(request.status).to.be.equal(500);
+              expect(request.statusText).to.be.equal('Internal Server Error');
+            });
       });
     });
   </script>


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more