### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-ajax.js
+++ b/iron-ajax.js
@@ -38,6 +38,7 @@ element.
 Polymer({
 
   is: 'iron-ajax',
+  _template: null,
 
   /**
    * Fired before a request is sent.

--- a/iron-request.js
+++ b/iron-request.js
@@ -20,6 +20,7 @@ iron-request can be used to perform XMLHttpRequests.
 */
 Polymer({
   is: 'iron-request',
+  _template: null,
 
   hostAttributes: {hidden: true},
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336